### PR TITLE
Pin current scheduling behavior with tests

### DIFF
--- a/tests/test_g_cal.py
+++ b/tests/test_g_cal.py
@@ -2,6 +2,145 @@ import pytest
 from src.g_cal import *
 
 
+def backlog(title, size="S", estimate=2, priority="P1"):
+    return ProjectItemDTO(
+        title=title, size=size, estimate=estimate, priority=priority, status="Backlog"
+    )
+
+
+def event(summary, start, end):
+    return {
+        "summary": summary,
+        "start": {"dateTime": start},
+        "end": {"dateTime": end},
+    }
+
+
+def placements(tasks):
+    return [(task.title, task.startDate.isoformat(), task.endDate.isoformat()) for task in tasks]
+
+
+def test_scheduler_leaves_empty_backlog_empty():
+    assert (
+        schedule_events_from_project_items("2024-01-01", "2024-01-01", "09:00", "17:00", [], [])
+        == []
+    )  # correct behaviour
+
+
+def test_scheduler_places_single_item_that_fits():
+    result = schedule_events_from_project_items(
+        "2024-01-01", "2024-01-01", "09:00", "17:00", [], [backlog("A", estimate=2)]
+    )
+    assert placements(result) == [
+        ("A", "2024-01-01T09:00:00+00:00", "2024-01-01T11:00:00+00:00")
+    ]  # correct behaviour
+
+
+def test_scheduler_splits_item_around_existing_commitment():
+    result = schedule_events_from_project_items(
+        "2024-01-01",
+        "2024-01-01",
+        "09:00",
+        "17:00",
+        [event("Meeting", "2024-01-01T11:00:00+00:00", "2024-01-01T13:00:00+00:00")],
+        [backlog("A", estimate=6)],
+    )
+    assert placements(result) == [
+        ("A", "2024-01-01T09:00:00+00:00", "2024-01-01T11:00:00+00:00"),
+        ("A", "2024-01-01T13:00:00+00:00", "2024-01-01T17:00:00+00:00"),
+    ]  # correct behaviour
+
+
+def test_scheduler_swaps_second_large_item_for_smaller_item():
+    result = schedule_events_from_project_items(
+        "2024-01-01",
+        "2024-01-01",
+        "09:00",
+        "17:00",
+        [],
+        [backlog("Large 1", "L", 2), backlog("Large 2", "L", 2), backlog("Small", "S", 2)],
+    )
+    assert [task.title for task in result] == [
+        "Large 1",
+        "Large 2",
+        "Small",
+    ]  # preserved defect: the large-item swap branch is not reached for this ordering
+
+
+def test_scheduler_advances_when_no_smaller_item_can_be_swapped_in():
+    result = schedule_events_from_project_items(
+        "2024-01-01",
+        "2024-01-02",
+        "09:00",
+        "17:00",
+        [],
+        [backlog("Large 1", "L", 2), backlog("Large 2", "L", 2)],
+    )
+    assert placements(result) == [
+        ("Large 1", "2024-01-01T09:00:00+00:00", "2024-01-01T11:00:00+00:00")
+    ]  # preserved defect: advancing inside the loop skips the next day
+
+
+def test_scheduler_rolls_over_an_item_across_days():
+    result = schedule_events_from_project_items(
+        "2024-01-01", "2024-01-02", "09:00", "17:00", [], [backlog("A", estimate=10)]
+    )
+    assert placements(result) == [
+        ("A", "2024-01-01T09:00:00+00:00", "2024-01-01T17:00:00+00:00"),
+        ("A", "2024-01-02T09:00:00+00:00", "2024-01-02T11:00:00+00:00"),
+    ]  # correct behaviour
+
+
+def test_scheduler_does_not_place_item_when_window_cannot_fit_it():
+    result = schedule_events_from_project_items(
+        "2024-01-01", "2024-01-01", "09:00", "17:00", [], [backlog("A", estimate=9)]
+    )
+    assert placements(result) == [
+        ("A", "2024-01-01T09:00:00+00:00", "2024-01-01T17:00:00+00:00")
+    ]  # preserved defect: an oversized item is truncated instead of rejected
+
+
+def test_scheduler_uses_size_when_estimate_is_missing():
+    result = schedule_events_from_project_items(
+        "2024-01-01", "2024-01-01", "09:00", "17:00", [], [backlog("A", "M", None)]
+    )
+    assert placements(result) == [
+        ("A", "2024-01-01T09:00:00+00:00", "2024-01-01T13:00:00+00:00")
+    ]  # correct behaviour
+
+
+def test_scheduler_sorts_existing_commitments_before_finding_slot():
+    result = schedule_events_from_project_items(
+        "2024-01-01",
+        "2024-01-01",
+        "09:00",
+        "17:00",
+        [
+            event("Late", "2024-01-01T13:00:00+00:00", "2024-01-01T14:00:00+00:00"),
+            event("Early", "2024-01-01T10:00:00+00:00", "2024-01-01T11:00:00+00:00"),
+        ],
+        [backlog("A", estimate=2)],
+    )
+    assert placements(result) == [
+        ("A", "2024-01-01T09:00:00+00:00", "2024-01-01T11:00:00+00:00")
+    ]  # preserved defect: unsorted commitments make the algorithm choose this gap
+
+
+def test_scheduler_preserves_offset_event_clock_as_utc():
+    result = schedule_events_from_project_items(
+        "2024-01-01",
+        "2024-01-01",
+        "09:00",
+        "17:00",
+        [event("Meeting", "2024-01-01T10:00:00+01:00", "2024-01-01T12:00:00+01:00")],
+        [backlog("A", estimate=2)],
+    )
+    assert placements(result) == [
+        ("A", "2024-01-01T09:00:00+00:00", "2024-01-01T10:00:00+00:00"),
+        ("A", "2024-01-01T12:00:00+00:00", "2024-01-01T13:00:00+00:00"),
+    ]  # preserved defect: the offset clock is relabelled UTC instead of converted
+
+
 @pytest.fixture
 def mock_service(mocker):
     # Mock the Google Calendar service


### PR DESCRIPTION
## What changed

Added ten characterization scenarios for the scheduling algorithm, including offset timestamps, backlog ordering, rollover, commitments, estimates, and known edge cases.

## Why / Context

The scheduler is due for refactoring. These tests capture its current output before production behavior changes, including explicit assertions for preserved defects.

## How to test

Run:

```bash
UV_CACHE_DIR=/tmp/uv-cache uv run pytest
UV_CACHE_DIR=/tmp/uv-cache uv run ruff check tests/test_g_cal.py
```

The suite should report 19 passing tests and Ruff should report no issues.

## Checklist

- [x] No production code changed
- [x] Offset-suffixed timestamps used
- [x] Known defects are labeled in assertions
- [x] Full test suite passes