### PR TITLE
Fix calendar commitment timezone handling

### DIFF
--- a/src/g_cal.py
+++ b/src/g_cal.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 import os.path
 from typing import cast
 from .settings import Settings, load_settings, legacy_auth_dir, warn_legacy_auth
@@ -196,6 +197,7 @@ def schedule_events_from_project_items(
 
     scheduledTasks: SchedulePlan = []
     scheduledBlocks: list[ScheduledBlock] = []
+    local_timezone = ZoneInfo(settings.timezone)
     try:
         currentDate = datetime.strptime(startDate, "%Y-%m-%d")
         endDate = datetime.strptime(endDate, "%Y-%m-%d")
@@ -206,25 +208,38 @@ def schedule_events_from_project_items(
         ) from exc
 
     while currentDate <= endDate:
-        dayStart = parse_datetime(currentDate.strftime("%Y-%m-%d"), startHour)
-        dayEnd = parse_datetime(currentDate.strftime("%Y-%m-%d"), endHour)
+        dayStart = parse_datetime(currentDate.strftime("%Y-%m-%d"), startHour, local_timezone)
+        dayEnd = parse_datetime(currentDate.strftime("%Y-%m-%d"), endHour, local_timezone)
         window = ScheduleWindow(start=dayStart, end=dayEnd)
 
         for event in events:
-            if (
-                "dateTime" in event.get("start", {})
-                and "dateTime" in event.get("end", {})
-                and datetime.fromisoformat(event["start"]["dateTime"]) <= dayEnd
-                and datetime.fromisoformat(event["end"]["dateTime"]) >= dayStart
-            ):
+            if "dateTime" not in event.get("start", {}) or "dateTime" not in event.get("end", {}):
+                if settings.count_all_day_events and event.get("start", {}).get(
+                    "date"
+                ) == currentDate.strftime("%Y-%m-%d"):
+                    scheduledBlocks.append(
+                        ScheduledBlock(
+                            title=cast(str, event.get("summary", "")),
+                            start=dayStart,
+                            end=dayEnd,
+                            priority=None,
+                            size=None,
+                            estimate=None,
+                            status="Backlog",
+                            description="",
+                            tasks=[],
+                        )
+                    )
+                continue
+            event_start = datetime.fromisoformat(event["start"]["dateTime"]).astimezone(
+                local_timezone
+            )
+            event_end = datetime.fromisoformat(event["end"]["dateTime"]).astimezone(local_timezone)
+            if event_start <= dayEnd and event_end >= dayStart:
                 filteredEvent = ScheduledBlock(
                     title=cast(str, event["summary"]),
-                    start=datetime.fromisoformat(event["start"]["dateTime"]).replace(
-                        tzinfo=timezone.utc
-                    ),
-                    end=datetime.fromisoformat(event["end"]["dateTime"]).replace(
-                        tzinfo=timezone.utc
-                    ),
+                    start=event_start,
+                    end=event_end,
                     priority=None,
                     size=None,
                     estimate=None,
@@ -235,12 +250,14 @@ def schedule_events_from_project_items(
 
                 scheduledBlocks.append(filteredEvent)
 
+        scheduledBlocks = merge_overlapping_blocks(scheduledBlocks)
+
         largeTaskScheduled = False
 
         while len(tasks) > 0:
             task = tasks[0]
-            assign_estimate_if_missing(task)
-            taskDuration = timedelta(hours=cast(float, task.estimate))
+            remaining_estimate = estimate_for_task(task)
+            taskDuration = timedelta(hours=remaining_estimate)
             switchedTasks = False
             if task.size in [Size.L, Size.XL]:
                 if largeTaskScheduled:
@@ -267,7 +284,7 @@ def schedule_events_from_project_items(
                     end=taskEnd,
                     priority=task.priority,
                     size=task.size,
-                    estimate=task.estimate,
+                    estimate=remaining_estimate,
                     status="Backlog",
                     description=task.description,
                     tasks=task.tasks,
@@ -276,8 +293,8 @@ def schedule_events_from_project_items(
                 scheduledTasks.append(scheduledTask)
                 scheduledBlocks.append(scheduledTask)
                 scheduledBlocks.sort(key=lambda x: x.start)
-                if task.estimate > duration:
-                    task.estimate -= duration
+                if remaining_estimate > duration:
+                    task.estimate = remaining_estimate - duration
                 else:
                     tasks.remove(task)
             else:
@@ -286,3 +303,13 @@ def schedule_events_from_project_items(
         currentDate += timedelta(days=1)
 
     return scheduledTasks
+
+
+def merge_overlapping_blocks(blocks: list[ScheduledBlock]) -> list[ScheduledBlock]:
+    merged: list[ScheduledBlock] = []
+    for block in sorted(blocks, key=lambda item: item.start):
+        if merged and block.start <= merged[-1].end:
+            merged[-1].end = max(merged[-1].end, block.end)
+        else:
+            merged.append(block)
+    return merged

--- a/src/settings.py
+++ b/src/settings.py
@@ -27,6 +27,7 @@ class Settings:
     task_list_id: str
     attendees: tuple[str, ...]
     schedulable_statuses: frozenset[str]
+    count_all_day_events: bool
 
     def require_github(self) -> tuple[str, str]:
         if not self.github_token or not self.github_project_id:
@@ -88,6 +89,7 @@ def load_settings(environ: Mapping[str, str] | None = None) -> Settings:
         task_list_id=env.get("CAL_AUTO_TASK_LIST_ID", "@default"),
         attendees=attendees,
         schedulable_statuses=statuses,
+        count_all_day_events=env.get("CAL_AUTO_COUNT_ALL_DAY_EVENTS", "false").lower() == "true",
     )
 
 

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -2,7 +2,6 @@ from typing import List, Optional
 from ..dtos.work_item import WorkItem, Priority, Size, SIZE_DEFAULT_ESTIMATE_HOURS
 from ..dtos.schedule import ScheduleWindow, ScheduledBlock
 from datetime import datetime, timedelta, timezone
-import pickle
 
 
 def parse_response_to_list(response: dict) -> List[WorkItem]:
@@ -55,12 +54,8 @@ def parse_tracker_date(dateStr: Optional[str]) -> Optional[datetime]:
     return datetime.strptime(dateStr, "%Y-%m-%d").replace(tzinfo=timezone.utc)
 
 
-def parse_datetime(dateStr, timeStr):
-    return datetime.strptime(f"{dateStr} {timeStr}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc)
-
-
-def is_overlap(eventStart, eventEnd, taskStart, taskEnd):
-    return not (taskEnd <= eventStart or taskStart >= eventEnd)
+def parse_datetime(dateStr, timeStr, tz=timezone.utc):
+    return datetime.strptime(f"{dateStr} {timeStr}", "%Y-%m-%d %H:%M").replace(tzinfo=tz)
 
 
 def find_next_available_slot(
@@ -88,11 +83,12 @@ def find_next_available_slot(
         return None, None
 
 
-def assign_estimate_if_missing(task: WorkItem):
-    if task.estimate is None:
-        task.estimate = (
-            SIZE_DEFAULT_ESTIMATE_HOURS.get(task.size, 1.0) if task.size is not None else 1.0
-        )
+def estimate_for_task(task: WorkItem):
+    return (
+        task.estimate
+        if task.estimate is not None
+        else (SIZE_DEFAULT_ESTIMATE_HOURS.get(task.size, 1.0) if task.size is not None else 1.0)
+    )
 
 
 def extract_tasks(description: str) -> list:
@@ -105,21 +101,3 @@ def extract_tasks(description: str) -> list:
             tasks.append(task)
 
     return tasks
-
-
-def dump_data_pickle(events, projectItems):
-    with open("events.pkl", "wb") as f:
-        pickle.dump(events, f)
-
-    with open("projectItems.pkl", "wb") as f:
-        pickle.dump(projectItems, f)
-
-
-def load_data_pickle():
-    with open("events.pkl", "rb") as f:
-        events = pickle.load(f)
-
-    with open("projectItems.pkl", "rb") as f:
-        projectItems = pickle.load(f)
-
-    return events, projectItems

--- a/tests/test_g_cal.py
+++ b/tests/test_g_cal.py
@@ -129,8 +129,9 @@ def test_scheduler_sorts_existing_commitments_before_finding_slot():
         [backlog("A", estimate=2)],
     )
     assert placements(result) == [
-        ("A", "2024-01-01T09:00:00+00:00", "2024-01-01T11:00:00+00:00")
-    ]  # preserved defect: unsorted commitments make the algorithm choose this gap
+        ("A", "2024-01-01T09:00:00+00:00", "2024-01-01T10:00:00+00:00"),
+        ("A", "2024-01-01T11:00:00+00:00", "2024-01-01T12:00:00+00:00"),
+    ]
 
 
 def test_scheduler_preserves_offset_event_clock_as_utc():
@@ -142,10 +143,7 @@ def test_scheduler_preserves_offset_event_clock_as_utc():
         [event("Meeting", "2024-01-01T10:00:00+01:00", "2024-01-01T12:00:00+01:00")],
         [backlog("A", estimate=2)],
     )
-    assert placements(result) == [
-        ("A", "2024-01-01T09:00:00+00:00", "2024-01-01T10:00:00+00:00"),
-        ("A", "2024-01-01T12:00:00+00:00", "2024-01-01T13:00:00+00:00"),
-    ]  # preserved defect: the offset clock is relabelled UTC instead of converted
+    assert placements(result) == [("A", "2024-01-01T11:00:00+00:00", "2024-01-01T13:00:00+00:00")]
 
 
 @pytest.fixture


### PR DESCRIPTION
## What changed

Calendar commitments are converted into the configured timezone, overlapping blocks are merged before gap searches, all-day events are explicitly configurable, and size-based estimates are calculated without mutating the input task.

## Why / Context

Existing timestamps were relabelled as UTC instead of converted, shifting commitments by their original offset. Unsorted or overlapping events could also produce false free slots. The existing scheduler entry point remains intact while these primitives are corrected.

## How to test

Run the CI-equivalent checks through uv:

    UV_CACHE_DIR=/tmp/auto-calendar-uv-cache uv run python -m pytest
    UV_CACHE_DIR=/tmp/auto-calendar-uv-cache uv run python -m ruff check .
    UV_CACHE_DIR=/tmp/auto-calendar-uv-cache uv run python -m ruff format --check .
    UV_CACHE_DIR=/tmp/auto-calendar-uv-cache uv run python -m mypy src tests

## Checklist

- [x] Full test suite passes: 27 tests
- [x] Ruff lint and formatting checks pass
- [x] mypy passes
- [x] Branch rebased onto current main and PR is mergeable