### PR TITLE
Put the GitHub task source behind a TaskSource interface

### DIFF
--- a/src/ghub.py
+++ b/src/ghub.py
@@ -1,10 +1,19 @@
+from typing import Iterable, List, Optional
+
 import requests
+
+from .providers.task_source import TaskSource
 from .utils.utils import parse_response_to_list
 from .settings import Settings, load_settings, legacy_auth_dir, warn_legacy_auth
 from .errors import IntegrationError
+from .dtos.work_item import WorkItem
 
 
 url = "https://api.github.com/graphql"
+
+# The query below requests a single page of 100 items with no pagination. A board with more than
+# 100 items will silently lose the overflow. Revisit if boards regularly exceed this size.
+PAGE_SIZE = 100
 
 
 def get_github_auth(settings: Settings | None = None):
@@ -22,7 +31,7 @@ def get_github_query(projectID):
     query{{
     node(id: "{projectID}") {{
         ... on ProjectV2 {{
-            items(first: 100) {{
+            items(first: {PAGE_SIZE}) {{
             nodes{{
                 id
                 fieldValues(first: 100) {{
@@ -114,3 +123,16 @@ def get_github_project_items(token, projectID):
             f"Failed to fetch project items from GitHub: {e}",
             hint="Check your network connection and that GITHUB_TOKEN has access to the project.",
         ) from e
+
+
+class GitHubProjectsTaskSource(TaskSource):
+    def __init__(self, token: str, project_id: str):
+        self.token = token
+        self.project_id = project_id
+
+    def list_work_items(self, statuses: Optional[Iterable[str]] = None) -> List[WorkItem]:
+        items = get_github_project_items(self.token, self.project_id)
+        if statuses is None:
+            return items
+        wanted = set(statuses)
+        return [item for item in items if item.status in wanted]

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,8 @@ def main():
         list_all_google_tasks(taskService, settings)
         events = list_all_google_events(calService, settings)
         token, projectId = get_github_auth(settings)
-        projectItems = get_github_project_items(token, projectId)
+        taskSource = GitHubProjectsTaskSource(token, projectId)
+        projectItems = taskSource.list_work_items()
 
         schedule_start = date.today()
         schedule_end = schedule_start + timedelta(days=2)

--- a/src/providers/calendar_sink.py
+++ b/src/providers/calendar_sink.py
@@ -1,0 +1,24 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from ..dtos.event import EventDTO
+from ..dtos.schedule import ScheduleWindow, ScheduledBlock
+from ..dtos.task import TaskDTO
+
+
+class CalendarSink(ABC):
+    @abstractmethod
+    def list_busy_blocks(self, window: ScheduleWindow) -> List[ScheduledBlock]:
+        """Return the blocks already occupying the given window."""
+
+    @abstractmethod
+    def create_event(self, event: EventDTO) -> dict:
+        """Create a calendar event and return the created resource."""
+
+    @abstractmethod
+    def create_todo(self, task: TaskDTO) -> dict:
+        """Create a to-do item and return the created resource."""
+
+    @abstractmethod
+    def find_existing_event(self, title: str, window: ScheduleWindow) -> Optional[dict]:
+        """Look up a previously created event with the given title in the window, if any."""

--- a/src/providers/task_source.py
+++ b/src/providers/task_source.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+from typing import Iterable, List, Optional
+
+from ..dtos.work_item import WorkItem
+
+
+class TaskSource(ABC):
+    @abstractmethod
+    def list_work_items(self, statuses: Optional[Iterable[str]] = None) -> List[WorkItem]:
+        """Return work items, optionally restricted to the given statuses."""

--- a/tests/test_ghub.py
+++ b/tests/test_ghub.py
@@ -1,8 +1,9 @@
 import pytest
 import requests
 
+from src.dtos.work_item import Priority, WorkItem
 from src.errors import ConfigurationError, IntegrationError
-from src.ghub import get_github_project_items
+from src.ghub import GitHubProjectsTaskSource, get_github_project_items
 from src.settings import load_settings
 
 
@@ -23,6 +24,15 @@ def test_get_github_project_items_raises_integration_error_on_request_failure(mo
         get_github_project_items("token", "project-id")
 
 
+def test_get_github_project_items_raises_integration_error_on_non_success_status(mocker):
+    response = mocker.Mock()
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError("401 Unauthorized")
+    mocker.patch("src.ghub.requests.post", return_value=response)
+
+    with pytest.raises(IntegrationError, match="Failed to fetch project items from GitHub"):
+        get_github_project_items("token", "project-id")
+
+
 def test_get_github_project_items_raises_integration_error_on_graphql_errors(mocker):
     response = mocker.Mock()
     response.json.return_value = {
@@ -33,3 +43,92 @@ def test_get_github_project_items_raises_integration_error_on_graphql_errors(moc
 
     with pytest.raises(IntegrationError, match="GitHub returned errors"):
         get_github_project_items("token", "project-id")
+
+
+def test_get_github_project_items_returns_empty_list_for_empty_board(mocker):
+    response = mocker.Mock()
+    response.json.return_value = {"data": {"node": {"items": {"nodes": []}}}}
+    mocker.patch("src.ghub.requests.post", return_value=response)
+
+    assert get_github_project_items("token", "project-id") == []
+
+
+def test_get_github_project_items_maps_response_to_work_items(mocker):
+    response = mocker.Mock()
+    response.json.return_value = {
+        "data": {
+            "node": {
+                "items": {
+                    "nodes": [
+                        {
+                            "id": "item-1",
+                            "fieldValues": {
+                                "nodes": [
+                                    {"text": "Task A", "field": {"name": "Title"}},
+                                    {"name": "P1", "field": {"name": "Priority"}},
+                                    {"name": "Backlog", "field": {"name": "Status"}},
+                                ]
+                            },
+                            "content": {
+                                "title": "Task A",
+                                "body": "",
+                                "assignees": {"nodes": [{"login": "userA"}]},
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    mocker.patch("src.ghub.requests.post", return_value=response)
+
+    items = get_github_project_items("token", "project-id")
+
+    assert items == [
+        WorkItem(
+            id="item-1",
+            title="Task A",
+            assignee="userA",
+            priority=Priority.P1,
+            status="Backlog",
+        )
+    ]
+
+
+class TestGitHubProjectsTaskSource:
+    def test_list_work_items_returns_everything_without_a_status_filter(self, mocker):
+        mocker.patch(
+            "src.ghub.get_github_project_items",
+            return_value=[
+                WorkItem(id="1", status="Backlog"),
+                WorkItem(id="2", status="Done"),
+            ],
+        )
+
+        source = GitHubProjectsTaskSource("token", "project-id")
+
+        assert [item.id for item in source.list_work_items()] == ["1", "2"]
+
+    def test_list_work_items_filters_by_status(self, mocker):
+        mocker.patch(
+            "src.ghub.get_github_project_items",
+            return_value=[
+                WorkItem(id="1", status="Backlog"),
+                WorkItem(id="2", status="Done"),
+            ],
+        )
+
+        source = GitHubProjectsTaskSource("token", "project-id")
+
+        assert [item.id for item in source.list_work_items(statuses=["Backlog"])] == ["1"]
+
+    def test_list_work_items_propagates_integration_errors(self, mocker):
+        mocker.patch(
+            "src.ghub.get_github_project_items",
+            side_effect=IntegrationError("boom", hint="check the board"),
+        )
+
+        source = GitHubProjectsTaskSource("token", "project-id")
+
+        with pytest.raises(IntegrationError, match="boom"):
+            source.list_work_items()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,14 @@
+import pytest
+
+from src.providers.calendar_sink import CalendarSink
+from src.providers.task_source import TaskSource
+
+
+def test_task_source_cannot_be_instantiated_directly():
+    with pytest.raises(TypeError):
+        TaskSource()
+
+
+def test_calendar_sink_cannot_be_instantiated_directly():
+    with pytest.raises(TypeError):
+        CalendarSink()


### PR DESCRIPTION
## What changed

Introduces `TaskSource` and `CalendarSink` abstract interfaces under `src/providers/`. GitHub's
project-board client now implements `TaskSource` via `GitHubProjectsTaskSource`, which wraps the
existing GraphQL fetch/parse and adds optional client-side status filtering. `main.py` goes through
that class instead of calling the GitHub functions directly.

## Why / Context

The tracker query, HTTP call, response parsing and scheduler input were tangled together, so adding
a second tracker meant touching the scheduler. `TaskSource` gives the scheduler a stable input
shape regardless of where work items come from. `CalendarSink` is defined now, alongside it, even
though the Google Calendar implementation lands in a later ticket, so the pair is reviewed as one
shape — per plan, no plugin discovery is built for what is currently one implementation, a direct
`GitHubProjectsTaskSource(...)` instantiation is enough.

The page size of 100 items with no pagination is existing behaviour and is now called out as a
known constraint at the query definition (`PAGE_SIZE` in `ghub.py`).

The errors-field and non-success-status handling in `get_github_project_items` (raising
`IntegrationError` instead of silently parsing an errors payload as an empty board) predates this
change; this PR adds fixture-driven coverage for those paths plus the empty-board and successful
mapping cases, all against a mocked `requests.post` — no network access.

## How to test

`uv run pytest -q` — covers the new interfaces, `GitHubProjectsTaskSource` status filtering, and
the tracker error/empty/mapping fixtures. `uv run mypy src` and `uv run ruff check .` both pass.

## Checklist

- [ ] `CalendarSink` shape reviewed even though nothing implements it yet
- [ ] `PAGE_SIZE` constraint comment reads clearly at the query site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving GitHub Projects work items, including optional filtering by status.
  * Added provider interfaces for task sources and calendar integrations.

* **Bug Fixes**
  * Improved handling of GitHub Project responses, including empty boards and integration errors.

* **Tests**
  * Expanded coverage for work-item mapping, status filtering, HTTP failures, and provider interface behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->