### PR TITLE
Separate calendar authorization from server startup

### DIFF
--- a/src/g_cal.py
+++ b/src/g_cal.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
-import os.path
+import os
 from typing import cast
 from .settings import Settings, load_settings, legacy_auth_dir, warn_legacy_auth
 from .errors import (
@@ -27,17 +27,32 @@ import random
 SCOPES = ["https://www.googleapis.com/auth/calendar", "https://www.googleapis.com/auth/tasks"]
 
 
-def authenticate(settings: Settings | None = None):
+def _check_token_permissions(token_path):
+    mode = os.stat(token_path).st_mode & 0o777
+    if mode & 0o077:
+        raise AuthorizationError(
+            f"Google token file {token_path} is readable by other users",
+            hint=f"Run chmod 600 {token_path}.",
+        )
+
+
+def _save_credentials(creds, token_path):
+    with open(token_path, "w", opener=lambda path, flags: os.open(path, flags, 0o600)) as token:
+        token.write(creds.to_json())
+    os.chmod(token_path, 0o600)
+
+
+def load_credentials(settings: Settings | None = None):
     settings = settings or load_settings()
     creds = None
-    tokenPath = settings.google_token_file
-    credentialsPath = settings.google_credentials_file
+    token_path = settings.google_token_file
     legacy = legacy_auth_dir()
     if (legacy / "credentials.json").exists() or (legacy / "token.json").exists():
         warn_legacy_auth(legacy)
 
-    if os.path.exists(tokenPath):
-        creds = Credentials.from_authorized_user_file(tokenPath, SCOPES)
+    if token_path.exists():
+        _check_token_permissions(token_path)
+        creds = Credentials.from_authorized_user_file(token_path, SCOPES)
 
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -45,32 +60,44 @@ def authenticate(settings: Settings | None = None):
                 creds.refresh(Request())
             except RefreshError as exc:
                 raise AuthorizationExpiredError(
-                    "Google authorisation has expired and could not be refreshed",
-                    hint=f"Delete {tokenPath} and rerun to reauthorise.",
+                    "Stored Google authorisation could not be refreshed",
+                    hint="Run cal-auto-python authorize to authorise the account again.",
                 ) from exc
         else:
-            if not os.path.exists(credentialsPath):
-                raise ConfigurationError(
-                    f"Missing Google OAuth client file: {credentialsPath}",
-                    hint=(
-                        "Download an OAuth client ID (Desktop app) from the Google Cloud "
-                        f"Console and save it to {credentialsPath}."
-                    ),
-                )
-            try:
-                flow = InstalledAppFlow.from_client_secrets_file(credentialsPath, SCOPES)
-                creds = flow.run_local_server(port=0)
-            except Exception as exc:
-                raise AuthorizationError(
-                    "Google Calendar/Tasks authorisation was not completed",
-                    hint="Rerun the tool and grant access in the browser window that opens.",
-                ) from exc
+            raise AuthorizationError(
+                "Google account has not been authorised",
+                hint="Run cal-auto-python authorize before starting the server.",
+            )
 
-        with open(tokenPath, "w", opener=lambda path, flags: os.open(path, flags, 0o600)) as token:
-            token.write(creds.to_json())
-        os.chmod(tokenPath, 0o600)
+        _save_credentials(creds, token_path)
 
     return creds
+
+
+def authorize_credentials(settings: Settings | None = None):
+    settings = settings or load_settings()
+    credentials_path = settings.google_credentials_file
+    if not credentials_path.exists():
+        raise ConfigurationError(
+            f"Missing Google OAuth client file: {credentials_path}",
+            hint=(
+                "Download an OAuth client ID (Desktop app) from the Google Cloud "
+                f"Console and save it to {credentials_path}."
+            ),
+        )
+    try:
+        flow = InstalledAppFlow.from_client_secrets_file(credentials_path, SCOPES)
+        creds = flow.run_local_server(port=0)
+    except Exception as exc:
+        raise AuthorizationError(
+            "Google Calendar/Tasks authorisation was not completed",
+            hint="Rerun cal-auto-python authorize and grant access in the browser window that opens.",
+        ) from exc
+    _save_credentials(creds, settings.google_token_file)
+    return creds
+
+
+authenticate = load_credentials
 
 
 def get_calendar_service(creds: Credentials):

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ from .logger import logger
 def main():
     try:
         settings = load_settings()
-        creds = authenticate(settings)
+        creds = load_credentials(settings)
         calService = get_calendar_service(creds)
         taskService = get_tasks_service(creds)
         list_all_google_tasks(taskService, settings)

--- a/tests/test_g_cal.py
+++ b/tests/test_g_cal.py
@@ -1,5 +1,10 @@
 import pytest
-from src.errors import ConfigurationError, SchedulingError
+from google.auth.exceptions import RefreshError
+from src.errors import (
+    AuthorizationError,
+    AuthorizationExpiredError,
+    SchedulingError,
+)
 from src.g_cal import *
 from src.dtos.work_item import Priority, Size
 from src.settings import load_settings
@@ -208,11 +213,59 @@ def test_list_all_google_tasks_succeeds_when_a_task_has_no_due_date(mocker):
     assert [item["id"] for item in items] == ["1", "2"]
 
 
-def test_authenticate_raises_configuration_error_when_credentials_file_missing(tmp_path):
+def test_load_credentials_requires_authorization_when_token_file_missing(tmp_path):
     settings = load_settings({"CAL_AUTO_CONFIG_DIR": str(tmp_path)})
 
-    with pytest.raises(ConfigurationError, match="Missing Google OAuth client file"):
-        authenticate(settings)
+    with pytest.raises(AuthorizationError, match="cal-auto-python authorize"):
+        load_credentials(settings)
+
+
+def test_load_credentials_requires_one_off_authorization_without_network(tmp_path, mocker):
+    settings = load_settings({"CAL_AUTO_CONFIG_DIR": str(tmp_path)})
+    request = mocker.patch("src.g_cal.Request")
+    browser = mocker.patch("src.g_cal.InstalledAppFlow")
+
+    with pytest.raises(AuthorizationError, match="cal-auto-python authorize"):
+        load_credentials(settings)
+
+    request.assert_not_called()
+    browser.assert_not_called()
+
+
+def test_load_credentials_reports_refresh_failure_separately(tmp_path, mocker):
+    settings = load_settings({"CAL_AUTO_CONFIG_DIR": str(tmp_path)})
+    settings.google_token_file.write_text("token")
+    settings.google_token_file.chmod(0o600)
+    credentials = mocker.Mock(valid=False, expired=True, refresh_token="refresh")
+    mocker.patch("src.g_cal.Credentials.from_authorized_user_file", return_value=credentials)
+    credentials.refresh.side_effect = RefreshError("expired")
+
+    with pytest.raises(AuthorizationExpiredError, match="could not be refreshed"):
+        load_credentials(settings)
+
+
+def test_load_credentials_rejects_token_readable_by_group(tmp_path):
+    settings = load_settings({"CAL_AUTO_CONFIG_DIR": str(tmp_path)})
+    settings.google_token_file.write_text("token")
+    settings.google_token_file.chmod(0o640)
+
+    with pytest.raises(AuthorizationError, match="readable by other users"):
+        load_credentials(settings)
+
+
+def test_authorize_credentials_is_the_only_browser_flow(tmp_path, mocker):
+    settings = load_settings({"CAL_AUTO_CONFIG_DIR": str(tmp_path)})
+    settings.google_credentials_file.write_text("credentials")
+    flow = mocker.patch("src.g_cal.InstalledAppFlow.from_client_secrets_file")
+    credentials = mocker.Mock()
+    credentials.to_json.return_value = "token"
+    flow.return_value.run_local_server.return_value = credentials
+
+    authorize_credentials(settings)
+
+    flow.assert_called_once()
+    assert settings.google_token_file.read_text() == "token"
+    assert settings.google_token_file.stat().st_mode & 0o777 == 0o600
 
 
 def test_list_all_google_tasks_returns_empty_list_when_no_tasks(mocker):


### PR DESCRIPTION
## What changed

Credential loading is now non-interactive. Browser-based Google authorization lives in a separate setup function, and token files must be owner-readable only.

## Why / Context

The server previously opened an OAuth browser flow when no usable token existed, causing background clients to hang indefinitely. Missing authorization and failed token refreshes now produce distinct actionable errors.

## How to test

Run:

```bash
XDG_CONFIG_HOME=/tmp/auto-calendar-config uv run pytest -q
uv run ruff check .
uv build --wheel
```

The suite verifies that the server path does not invoke the browser flow, refresh failures are distinct, setup errors name `cal-auto-python authorize`, and token permissions are restricted to `0600`.

## Checklist

- [x] Full test suite passes locally
- [x] Ruff checks pass
- [x] Wheel build passes
- [x] No browser flow is reachable from server startup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection for saved authentication tokens by enforcing restrictive file permissions.
  * Added checks to prevent use of tokens with insecure permissions.

* **Bug Fixes**
  * Improved handling of expired or invalid credentials, including clearer authorization errors.
  * Added reliable credential refresh behavior when existing authentication can be renewed.

* **Authentication**
  * Added a dedicated browser-based authorization flow when reauthorization is required.
  * Validates the OAuth client configuration before starting authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->