### PR TITLE
Dedupe events and to-dos when a plan is applied twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ $ uv run cal-auto-python
 [x] ~~Retrieve project data from github~~ \
 [x] ~~Add events and tasks to google calendar~~ \
 [x] ~~Schedule based on priority~~ \
+[x] ~~Fix duplicated events and tasks~~ \
 [ ] Optimize event distribution \
-[ ] Fix duplicated events and tasks
+[ ] Update or move an event when the plan changes
 
 ## References
 

--- a/src/dtos/event.py
+++ b/src/dtos/event.py
@@ -13,6 +13,7 @@ class EventDTO:
     recurrence: Optional[List[str]] = None
     attendees: Optional[List[Dict[str, str]]] = None
     reminders: Optional[Dict[str, Optional[bool]]] = None
+    extendedProperties: Optional[Dict[str, Dict[str, str]]] = None
 
     def __post_init__(self) -> None:
         if not self.summary:

--- a/src/dtos/schedule.py
+++ b/src/dtos/schedule.py
@@ -22,6 +22,7 @@ class ScheduledBlock:
     status: Optional[str] = None
     description: Optional[str] = None
     tasks: Optional[List[str]] = None
+    source: Optional[str] = None
     source_id: Optional[str] = None
 
 

--- a/src/dtos/work_item.py
+++ b/src/dtos/work_item.py
@@ -32,6 +32,7 @@ SIZE_DEFAULT_ESTIMATE_HOURS: Dict[Size, float] = {
 @dataclass
 class WorkItem:
     id: Optional[str] = None
+    source: Optional[str] = None
     title: Optional[str] = None
     assignee: Optional[str] = None
     start: Optional[datetime] = None

--- a/src/main.py
+++ b/src/main.py
@@ -54,7 +54,7 @@ def main():
             if not (
                 task.source
                 and task.source_id
-                and sink.has_scheduled_event(task.source, task.source_id)
+                and sink.has_scheduled_event(task.source, task.source_id, task.start)
             ):
                 event = build_event(task, settings)
                 sink.create_event(event)

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,12 @@ from .dtos.schedule import ScheduleWindow
 from .errors import AutoCalendarError
 from .ghub import GitHubProjectsTaskSource, get_github_auth
 from .logger import logger
-from .providers.google_calendar_sink import GoogleCalendarSink, build_event, build_todos
+from .providers.google_calendar_sink import (
+    GoogleCalendarSink,
+    build_event,
+    build_todos,
+    todo_marker,
+)
 from .scheduler import schedule
 from .settings import load_settings
 
@@ -43,13 +48,24 @@ def main():
         projectItems = taskSource.list_work_items()
 
         plan = schedule(projectItems, busy_blocks, window)
+        existing_todo_markers = sink.list_scheduled_todo_markers()
 
         for task in plan.scheduled:
-            event = build_event(task, settings)
-            sink.create_event(event)
+            if not (
+                task.source
+                and task.source_id
+                and sink.has_scheduled_event(task.source, task.source_id)
+            ):
+                event = build_event(task, settings)
+                sink.create_event(event)
 
-            for todo in build_todos(task):
+            for index, todo in enumerate(build_todos(task)):
+                marker = todo_marker(task.source, task.source_id, index)
+                if marker and marker in existing_todo_markers:
+                    continue
                 sink.create_todo(todo)
+                if marker:
+                    existing_todo_markers.add(marker)
 
             logger.info(
                 f"Task '{task.title}' scheduled from {task.start} to {task.end} with priority {task.priority} and size {task.size}, estimate: {task.estimate} hours."

--- a/src/providers/calendar_sink.py
+++ b/src/providers/calendar_sink.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Set
 
 from ..dtos.event import EventDTO
 from ..dtos.schedule import ScheduleWindow, ScheduledBlock
@@ -20,5 +20,9 @@ class CalendarSink(ABC):
         """Create a to-do item and return the created resource."""
 
     @abstractmethod
-    def find_existing_event(self, title: str, window: ScheduleWindow) -> Optional[dict]:
-        """Look up a previously created event with the given title in the window, if any."""
+    def has_scheduled_event(self, source: str, source_id: str) -> bool:
+        """Return whether an event for the given source item already exists."""
+
+    @abstractmethod
+    def list_scheduled_todo_markers(self) -> Set[str]:
+        """Return the markers of every to-do already created, fetched once per call."""

--- a/src/providers/calendar_sink.py
+++ b/src/providers/calendar_sink.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import List, Set
 
 from ..dtos.event import EventDTO
@@ -20,8 +21,8 @@ class CalendarSink(ABC):
         """Create a to-do item and return the created resource."""
 
     @abstractmethod
-    def has_scheduled_event(self, source: str, source_id: str) -> bool:
-        """Return whether an event for the given source item already exists."""
+    def has_scheduled_event(self, source: str, source_id: str, start: datetime) -> bool:
+        """Return whether an event for this exact scheduled block already exists."""
 
     @abstractmethod
     def list_scheduled_todo_markers(self) -> Set[str]:

--- a/src/providers/google_calendar_sink.py
+++ b/src/providers/google_calendar_sink.py
@@ -1,6 +1,7 @@
 import hashlib
+import re
 from datetime import datetime, timezone
-from typing import List, Optional, cast
+from typing import List, Optional, Set, cast
 from zoneinfo import ZoneInfo
 
 from ..dtos.event import EventDTO
@@ -10,6 +11,14 @@ from ..settings import Settings, load_settings
 from .calendar_sink import CalendarSink
 
 EVENT_COLOR_COUNT = 11
+
+TODO_MARKER_PATTERN = re.compile(r"\[auto-calendar:[^:\]]+:[^:\]]+:\d+\]")
+
+
+def todo_marker(source: Optional[str], source_id: Optional[str], index: int) -> Optional[str]:
+    if not source or not source_id:
+        return None
+    return f"[auto-calendar:{source}:{source_id}:{index}]"
 
 
 def event_color_id(source_id: str) -> str:
@@ -75,6 +84,11 @@ def build_event(block: ScheduledBlock, settings: Settings) -> EventDTO:
         f"Priority: {priority_name} | Status: {block.status} | "
         f"Size {size_name} | Estimate: {block.estimate}"
     )
+    extended_properties = None
+    if block.source and block.source_id:
+        extended_properties = {
+            "private": {"source_system": block.source, "source_id": block.source_id}
+        }
     return EventDTO(
         summary=block.title,
         start={
@@ -88,20 +102,27 @@ def build_event(block: ScheduledBlock, settings: Settings) -> EventDTO:
         attendees=attendees or None,
         colorId=event_color_id(block.source_id or block.title),
         description=notes,
+        extendedProperties=extended_properties,
     )
 
 
 def build_todos(block: ScheduledBlock) -> List[TaskDTO]:
-    return [
-        TaskDTO(
-            kind="tasks#task",
-            title=item,
-            notes=f"Event: {block.title}",
-            status="needsAction",
-            due=block.end.strftime("%Y-%m-%dT%H:%M:%S") + "Z",
+    todos = []
+    for index, item in enumerate(block.tasks or []):
+        marker = todo_marker(block.source, block.source_id, index)
+        notes = f"Event: {block.title}"
+        if marker:
+            notes = f"{notes} {marker}"
+        todos.append(
+            TaskDTO(
+                kind="tasks#task",
+                title=item,
+                notes=notes,
+                status="needsAction",
+                due=block.end.strftime("%Y-%m-%dT%H:%M:%S") + "Z",
+            )
         )
-        for item in block.tasks or []
-    ]
+    return todos
 
 
 class GoogleCalendarSink(CalendarSink):
@@ -160,8 +181,39 @@ class GoogleCalendarSink(CalendarSink):
             .execute()
         )
 
-    def find_existing_event(self, title: str, window: ScheduleWindow) -> Optional[dict]:
-        for event in self.list_events(window):
-            if event.get("summary") == title:
-                return event
-        return None
+    def has_scheduled_event(self, source: str, source_id: str) -> bool:
+        result = (
+            self.calendar_service.events()
+            .list(
+                calendarId=self.settings.calendar_id,
+                privateExtendedProperty=[
+                    f"source_system={source}",
+                    f"source_id={source_id}",
+                ],
+                maxResults=1,
+            )
+            .execute()
+        )
+        return bool(result.get("items"))
+
+    def list_scheduled_todo_markers(self) -> Set[str]:
+        markers: Set[str] = set()
+        page_token = None
+        while True:
+            result = (
+                self.tasks_service.tasks()
+                .list(
+                    tasklist=self.settings.task_list_id,
+                    showCompleted=True,
+                    showHidden=True,
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+            for task in result.get("items", []):
+                match = TODO_MARKER_PATTERN.search(task.get("notes") or "")
+                if match:
+                    markers.add(match.group(0))
+            page_token = result.get("nextPageToken")
+            if not page_token:
+                return markers

--- a/src/providers/google_calendar_sink.py
+++ b/src/providers/google_calendar_sink.py
@@ -21,6 +21,14 @@ def todo_marker(source: Optional[str], source_id: Optional[str], index: int) -> 
     return f"[auto-calendar:{source}:{source_id}:{index}]"
 
 
+def block_identity(
+    source: Optional[str], source_id: Optional[str], start: Optional[datetime]
+) -> Optional[str]:
+    if not source or not source_id or start is None:
+        return None
+    return f"{source}:{source_id}:{start.isoformat()}"
+
+
 def event_color_id(source_id: str) -> str:
     digest = hashlib.sha256(source_id.encode("utf-8")).digest()
     return str((digest[0] % EVENT_COLOR_COUNT) + 1)
@@ -85,9 +93,14 @@ def build_event(block: ScheduledBlock, settings: Settings) -> EventDTO:
         f"Size {size_name} | Estimate: {block.estimate}"
     )
     extended_properties = None
-    if block.source and block.source_id:
+    identity = block_identity(block.source, block.source_id, block.start)
+    if identity and block.source and block.source_id:
         extended_properties = {
-            "private": {"source_system": block.source, "source_id": block.source_id}
+            "private": {
+                "source_system": block.source,
+                "source_id": block.source_id,
+                "auto_calendar_id": identity,
+            }
         }
     return EventDTO(
         summary=block.title,
@@ -181,15 +194,13 @@ class GoogleCalendarSink(CalendarSink):
             .execute()
         )
 
-    def has_scheduled_event(self, source: str, source_id: str) -> bool:
+    def has_scheduled_event(self, source: str, source_id: str, start: datetime) -> bool:
+        identity = block_identity(source, source_id, start)
         result = (
             self.calendar_service.events()
             .list(
                 calendarId=self.settings.calendar_id,
-                privateExtendedProperty=[
-                    f"source_system={source}",
-                    f"source_id={source_id}",
-                ],
+                privateExtendedProperty=[f"auto_calendar_id={identity}"],
                 maxResults=1,
             )
             .execute()

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -72,6 +72,7 @@ def schedule(
                 status=item.status,
                 description=item.description,
                 tasks=item.tasks,
+                source=item.source,
                 source_id=item.id,
             )
             scheduled.append(scheduled_block)

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -4,13 +4,13 @@ from ..dtos.schedule import ScheduleWindow, ScheduledBlock
 from datetime import datetime, timedelta, timezone
 
 
-def parse_response_to_list(response: dict) -> List[WorkItem]:
+def parse_response_to_list(response: dict, source: str = "github") -> List[WorkItem]:
     projectItems = []
 
     nodes = response.get("data", {}).get("node", {}).get("items", {}).get("nodes", [])
 
     for node in nodes:
-        projectItem = WorkItem(id=node["id"])
+        projectItem = WorkItem(id=node["id"], source=source)
         field_content = node.get("content", {})
         field_nodes = node.get("fieldValues", {}).get("nodes", [])
 

--- a/tests/test_ghub.py
+++ b/tests/test_ghub.py
@@ -87,6 +87,7 @@ def test_get_github_project_items_maps_response_to_work_items(mocker):
     assert items == [
         WorkItem(
             id="item-1",
+            source="github",
             title="Task A",
             assignee="userA",
             priority=Priority.P1,

--- a/tests/test_google_calendar_sink.py
+++ b/tests/test_google_calendar_sink.py
@@ -11,6 +11,7 @@ from src.providers.google_calendar_sink import (
     build_todos,
     event_color_id,
     event_to_busy_block,
+    todo_marker,
 )
 from src.settings import load_settings
 
@@ -164,6 +165,52 @@ def test_build_todos_creates_one_task_per_checkbox():
     assert [t.title for t in todos] == ["Do X", "Do Y"]
 
 
+def test_build_todos_embeds_a_marker_per_checkbox_when_source_is_known():
+    block = ScheduledBlock(
+        title="A",
+        start=datetime(2024, 1, 1, 9, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 1, 11, tzinfo=timezone.utc),
+        tasks=["Do X", "Do Y"],
+        source="github",
+        source_id="item-1",
+    )
+
+    todos = build_todos(block)
+
+    assert todo_marker("github", "item-1", 0) in todos[0].notes
+    assert todo_marker("github", "item-1", 1) in todos[1].notes
+    assert todos[0].notes != todos[1].notes
+
+
+def test_build_todos_omits_marker_without_a_source_id():
+    block = ScheduledBlock(
+        title="A",
+        start=datetime(2024, 1, 1, 9, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 1, 11, tzinfo=timezone.utc),
+        tasks=["Do X"],
+    )
+
+    todos = build_todos(block)
+
+    assert todos[0].notes == "Event: A"
+
+
+def test_build_event_carries_source_metadata_as_private_extended_properties(tmp_path):
+    block = ScheduledBlock(
+        title="A",
+        start=datetime(2024, 1, 1, 9, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 1, 11, tzinfo=timezone.utc),
+        source="github",
+        source_id="item-1",
+    )
+
+    dto = build_event(block, settings(tmp_path))
+
+    assert dto.to_dict()["extendedProperties"] == {
+        "private": {"source_system": "github", "source_id": "item-1"}
+    }
+
+
 def test_event_dto_rejects_an_empty_summary():
     with pytest.raises(ValueError, match="non-empty summary"):
         EventDTO(
@@ -247,18 +294,105 @@ def test_create_todo_inserts_into_the_configured_task_list(tmp_path, mocker):
     assert kwargs["tasklist"] == "tasks"
 
 
-def test_find_existing_event_matches_by_title_in_window(tmp_path, mocker):
+def test_has_scheduled_event_queries_by_private_extended_property(tmp_path, mocker):
     service = mocker.Mock()
     service.events.return_value.list.return_value.execute.return_value = {
-        "items": [
-            {
-                "summary": "A",
-                "start": {"dateTime": "2024-01-01T10:00:00+00:00"},
-                "end": {"dateTime": "2024-01-01T11:00:00+00:00"},
-            }
-        ]
+        "items": [{"summary": "A"}]
     }
     sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
 
-    assert sink.find_existing_event("A", window()) is not None
-    assert sink.find_existing_event("B", window()) is None
+    assert sink.has_scheduled_event("github", "item-1") is True
+    _, kwargs = service.events.return_value.list.call_args
+    assert kwargs["privateExtendedProperty"] == [
+        "source_system=github",
+        "source_id=item-1",
+    ]
+
+
+def test_has_scheduled_event_is_false_when_no_event_matches(tmp_path, mocker):
+    service = mocker.Mock()
+    service.events.return_value.list.return_value.execute.return_value = {"items": []}
+    sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
+
+    assert sink.has_scheduled_event("github", "item-1") is False
+
+
+def test_list_scheduled_todo_markers_scans_notes_across_pages(tmp_path, mocker):
+    service = mocker.Mock()
+    service.tasks.return_value.list.return_value.execute.side_effect = [
+        {
+            "items": [
+                {"notes": f"Event: A {todo_marker('github', 'item-1', 0)}"},
+                {"notes": "Event: B, no marker"},
+            ],
+            "nextPageToken": "page-2",
+        },
+        {"items": [{"notes": f"Event: C {todo_marker('github', 'item-2', 0)}"}]},
+    ]
+    sink = GoogleCalendarSink(mocker.Mock(), service, settings(tmp_path))
+
+    markers = sink.list_scheduled_todo_markers()
+
+    assert markers == {
+        todo_marker("github", "item-1", 0),
+        todo_marker("github", "item-2", 0),
+    }
+
+
+def test_applying_the_same_plan_twice_creates_each_event_and_todo_once(tmp_path, mocker):
+    calendar_service = mocker.Mock()
+    tasks_service = mocker.Mock()
+    created_events: list = []
+    created_todos: list = []
+
+    def list_events(**kwargs):
+        wanted = set(kwargs.get("privateExtendedProperty") or [])
+        matches = [event for event in created_events if wanted.issubset(set(event))]
+        return mocker.Mock(execute=lambda: {"items": matches})
+
+    def insert_event(calendarId, body):
+        created_events.append(
+            [
+                f"source_system={body['extendedProperties']['private']['source_system']}",
+                f"source_id={body['extendedProperties']['private']['source_id']}",
+            ]
+        )
+        return mocker.Mock(execute=lambda: body)
+
+    def list_tasks(**kwargs):
+        return mocker.Mock(execute=lambda: {"items": [{"notes": t.notes} for t in created_todos]})
+
+    def insert_todo(tasklist, body):
+        created_todos.append(TaskDTO(**body))
+        return mocker.Mock(execute=lambda: body)
+
+    calendar_service.events.return_value.list.side_effect = list_events
+    calendar_service.events.return_value.insert.side_effect = insert_event
+    tasks_service.tasks.return_value.list.side_effect = list_tasks
+    tasks_service.tasks.return_value.insert.side_effect = insert_todo
+
+    sink = GoogleCalendarSink(calendar_service, tasks_service, settings(tmp_path))
+    block = ScheduledBlock(
+        title="A",
+        start=datetime(2024, 1, 1, 9, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 1, 11, tzinfo=timezone.utc),
+        tasks=["Do X", "Do Y"],
+        source="github",
+        source_id="item-1",
+    )
+
+    def apply_plan():
+        existing_markers = sink.list_scheduled_todo_markers()
+        if not sink.has_scheduled_event(block.source, block.source_id):
+            sink.create_event(build_event(block, settings(tmp_path)))
+        for index, todo in enumerate(build_todos(block)):
+            marker = todo_marker(block.source, block.source_id, index)
+            if marker in existing_markers:
+                continue
+            sink.create_todo(todo)
+
+    apply_plan()
+    apply_plan()
+
+    assert len(created_events) == 1
+    assert len(created_todos) == 2

--- a/tests/test_google_calendar_sink.py
+++ b/tests/test_google_calendar_sink.py
@@ -7,6 +7,7 @@ from src.dtos.schedule import ScheduledBlock, ScheduleWindow
 from src.dtos.task import TaskDTO
 from src.providers.google_calendar_sink import (
     GoogleCalendarSink,
+    block_identity,
     build_event,
     build_todos,
     event_color_id,
@@ -207,7 +208,11 @@ def test_build_event_carries_source_metadata_as_private_extended_properties(tmp_
     dto = build_event(block, settings(tmp_path))
 
     assert dto.to_dict()["extendedProperties"] == {
-        "private": {"source_system": "github", "source_id": "item-1"}
+        "private": {
+            "source_system": "github",
+            "source_id": "item-1",
+            "auto_calendar_id": block_identity("github", "item-1", block.start),
+        }
     }
 
 
@@ -294,18 +299,18 @@ def test_create_todo_inserts_into_the_configured_task_list(tmp_path, mocker):
     assert kwargs["tasklist"] == "tasks"
 
 
-def test_has_scheduled_event_queries_by_private_extended_property(tmp_path, mocker):
+def test_has_scheduled_event_queries_by_a_single_block_identity_property(tmp_path, mocker):
     service = mocker.Mock()
     service.events.return_value.list.return_value.execute.return_value = {
         "items": [{"summary": "A"}]
     }
     sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
+    start = datetime(2024, 1, 1, 9, tzinfo=timezone.utc)
 
-    assert sink.has_scheduled_event("github", "item-1") is True
+    assert sink.has_scheduled_event("github", "item-1", start) is True
     _, kwargs = service.events.return_value.list.call_args
     assert kwargs["privateExtendedProperty"] == [
-        "source_system=github",
-        "source_id=item-1",
+        f"auto_calendar_id={block_identity('github', 'item-1', start)}"
     ]
 
 
@@ -314,7 +319,31 @@ def test_has_scheduled_event_is_false_when_no_event_matches(tmp_path, mocker):
     service.events.return_value.list.return_value.execute.return_value = {"items": []}
     sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
 
-    assert sink.has_scheduled_event("github", "item-1") is False
+    assert (
+        sink.has_scheduled_event("github", "item-1", datetime(2024, 1, 1, 9, tzinfo=timezone.utc))
+        is False
+    )
+
+
+def test_has_scheduled_event_does_not_match_a_different_chunk_of_the_same_item(tmp_path, mocker):
+    service = mocker.Mock()
+    sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
+    day_one = datetime(2024, 1, 1, 9, tzinfo=timezone.utc)
+    day_two = datetime(2024, 1, 2, 9, tzinfo=timezone.utc)
+
+    def list_events(**kwargs):
+        wanted = kwargs["privateExtendedProperty"][0]
+        matches = (
+            [{"summary": "A"}]
+            if wanted == f"auto_calendar_id={block_identity('github', 'item-1', day_one)}"
+            else []
+        )
+        return mocker.Mock(execute=lambda: {"items": matches})
+
+    service.events.return_value.list.side_effect = list_events
+
+    assert sink.has_scheduled_event("github", "item-1", day_one) is True
+    assert sink.has_scheduled_event("github", "item-1", day_two) is False
 
 
 def test_list_scheduled_todo_markers_scans_notes_across_pages(tmp_path, mocker):
@@ -346,16 +375,13 @@ def test_applying_the_same_plan_twice_creates_each_event_and_todo_once(tmp_path,
     created_todos: list = []
 
     def list_events(**kwargs):
-        wanted = set(kwargs.get("privateExtendedProperty") or [])
-        matches = [event for event in created_events if wanted.issubset(set(event))]
+        wanted = kwargs["privateExtendedProperty"][0]
+        matches = [event for event in created_events if event == wanted]
         return mocker.Mock(execute=lambda: {"items": matches})
 
     def insert_event(calendarId, body):
         created_events.append(
-            [
-                f"source_system={body['extendedProperties']['private']['source_system']}",
-                f"source_id={body['extendedProperties']['private']['source_id']}",
-            ]
+            f"auto_calendar_id={body['extendedProperties']['private']['auto_calendar_id']}"
         )
         return mocker.Mock(execute=lambda: body)
 
@@ -383,7 +409,7 @@ def test_applying_the_same_plan_twice_creates_each_event_and_todo_once(tmp_path,
 
     def apply_plan():
         existing_markers = sink.list_scheduled_todo_markers()
-        if not sink.has_scheduled_event(block.source, block.source_id):
+        if not sink.has_scheduled_event(block.source, block.source_id, block.start):
             sink.create_event(build_event(block, settings(tmp_path)))
         for index, todo in enumerate(build_todos(block)):
             marker = todo_marker(block.source, block.source_id, index)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,7 @@ def base_response():
             [{"login": "userA"}],
             WorkItem(
                 id="taskA",
+                source="github",
                 title="Task A",
                 assignee="userA",
                 start=datetime(2024, 5, 1, tzinfo=timezone.utc),
@@ -44,6 +45,7 @@ def base_response():
             [],
             WorkItem(
                 id="taskB",
+                source="github",
                 title="Task B",
                 assignee=None,
                 start=None,
@@ -62,6 +64,7 @@ def base_response():
             [{"login": "userB"}],
             WorkItem(
                 id="taskC",
+                source="github",
                 title="Task C",
                 assignee="userB",
                 start=None,


### PR DESCRIPTION
## What changed

Work items and scheduled blocks now carry a `source` (tracker name) alongside their existing id. Calendar events get that pair written into Google Calendar's private extended properties; to-dos get an equivalent `[auto-calendar:<source>:<source_id>:<index>]` marker embedded in their notes, since the Tasks API has no metadata field. Before applying a plan, the sync now checks `has_scheduled_event` per item and fetches the full to-do list once via `list_scheduled_todo_markers`, skipping anything already created.

## Why / Context

Nothing recorded that an item had already been scheduled, so every run duplicated every event and to-do for the whole backlog. That made the tool unsafe to run more than once, which defeats the point of automating it. Calendar events support private metadata queryable via `privateExtendedProperty`, so lookups there are exact. Tasks have no such facility, so the marker lives in the note text and the list is scanned once per run rather than once per item, to avoid an API call per to-do. Rescheduling an item when the plan changes is a separate, harder problem and stays out of scope — the roadmap now tracks it as its own item.

## How to test

`uv run python -m pytest -q` covers the new behaviour, including `test_applying_the_same_plan_twice_creates_each_event_and_todo_once` in `tests/test_google_calendar_sink.py`, which applies the same block twice against a stubbed calendar/tasks service and asserts exactly one event and one to-do per checkbox.

## Checklist

- [x] `uv run python -m ruff check .`
- [x] `uv run python -m ruff format --check .`
- [x] `uv run python -m pytest -q`
- [x] `uv run python -m mypy src tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source information to scheduled tasks and calendar events.
  * Added task markers and metadata to improve event tracking.
* **Bug Fixes**
  * Prevented duplicate calendar events and task entries when plans are applied repeatedly.
  * Improved detection of previously scheduled tasks across paginated calendar results.
* **Documentation**
  * Updated the roadmap to mark duplicate event and task handling as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->