### PR TITLE
Replace hardcoded entry point with a real CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,25 @@ export GITHUB_PROJECT_ID=PVT_xxxxxxxxxx
 
 3. Copy `.env.example` to `.env` if you use an environment loader. Configure optional calendar, attendee, timezone, working-hours, and schedulable-status values there.
 
-4. Run the script
+4. Authorise the Google account once:
 
 ```bash
-$ uv run cal-auto-python
+$ uv run cal-auto-python authorize
+```
+
+5. Preview the plan for the default date range (today plus the next two days):
+
+```bash
+$ uv run cal-auto-python sync
+```
+
+Previewing is the default: `sync` only fetches, plans, and reports what it would do. Pass `--apply`
+to actually create the events and tasks, and `--start`/`--end` (as `YYYY-MM-DD`) or
+`--working-day-start`/`--working-day-end` (as `HH:MM`) to override the date range and working
+hours:
+
+```bash
+$ uv run cal-auto-python sync --start 2026-08-17 --end 2026-08-21 --apply
 ```
 
 ## Roadmap
@@ -42,8 +57,10 @@ $ uv run cal-auto-python
 [x] ~~Add events and tasks to google calendar~~ \
 [x] ~~Schedule based on priority~~ \
 [x] ~~Fix duplicated events and tasks~~ \
+[x] ~~Replace the hardcoded entry point with a real CLI~~ \
 [ ] Optimize event distribution \
-[ ] Update or move an event when the plan changes
+[ ] Update or move an event when the plan changes \
+[ ] Run as an MCP server (`cal-auto-python server`)
 
 ## References
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,81 +1,137 @@
+import argparse
+import sys
+from dataclasses import replace
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from googleapiclient.errors import HttpError
 
-from .auth import get_calendar_service, get_tasks_service, load_credentials
+from .auth import authorize_credentials, get_calendar_service, get_tasks_service, load_credentials
 from .dtos.schedule import ScheduleWindow
 from .errors import AutoCalendarError
 from .ghub import GitHubProjectsTaskSource, get_github_auth
 from .logger import logger
-from .providers.google_calendar_sink import (
-    GoogleCalendarSink,
-    build_event,
-    build_todos,
-    todo_marker,
-)
-from .scheduler import schedule
-from .settings import load_settings
+from .providers.calendar_sink import CalendarSink
+from .providers.google_calendar_sink import GoogleCalendarSink
+from .providers.task_source import TaskSource
+from .settings import Settings, load_settings
+from .sync import SyncResult, run_sync
 
 
-def main():
-    try:
-        settings = load_settings()
-        creds = load_credentials(settings)
-        calService = get_calendar_service(creds)
-        taskService = get_tasks_service(creds)
-        sink = GoogleCalendarSink(calService, taskService, settings)
+def build_integrations(settings: Settings) -> tuple[TaskSource, CalendarSink]:
+    creds = load_credentials(settings)
+    calendar_service = get_calendar_service(creds)
+    tasks_service = get_tasks_service(creds)
+    calendar_sink = GoogleCalendarSink(calendar_service, tasks_service, settings)
 
-        tz = ZoneInfo(settings.timezone)
-        schedule_start = datetime.now(tz).date()
-        schedule_end = schedule_start + timedelta(days=2)
-        window = ScheduleWindow(
-            start=datetime.combine(
-                schedule_start,
-                datetime.strptime(settings.working_day_start, "%H:%M").time(),
-                tz,
-            ),
-            end=datetime.combine(
-                schedule_end,
-                datetime.strptime(settings.working_day_end, "%H:%M").time(),
-                tz,
-            ),
+    token, project_id = get_github_auth(settings)
+    task_source = GitHubProjectsTaskSource(token, project_id)
+
+    return task_source, calendar_sink
+
+
+def build_window(
+    settings: Settings, start_date: str | None, end_date: str | None
+) -> ScheduleWindow:
+    tz = ZoneInfo(settings.timezone)
+    start = (
+        datetime.strptime(start_date, "%Y-%m-%d").date() if start_date else datetime.now(tz).date()
+    )
+    end = datetime.strptime(end_date, "%Y-%m-%d").date() if end_date else start + timedelta(days=2)
+    return ScheduleWindow(
+        start=datetime.combine(
+            start, datetime.strptime(settings.working_day_start, "%H:%M").time(), tz
+        ),
+        end=datetime.combine(end, datetime.strptime(settings.working_day_end, "%H:%M").time(), tz),
+    )
+
+
+def report_sync_result(result: SyncResult) -> None:
+    for block in result.plan.scheduled:
+        logger.info(
+            f"Task '{block.title}' planned from {block.start} to {block.end} "
+            f"with priority {block.priority} and size {block.size}, estimate: {block.estimate} hours."
         )
-        busy_blocks = sink.list_busy_blocks(window)
+    for item in result.unscheduled:
+        logger.info(f"Could not place '{item.work_item.title}': {item.reason}")
+    if result.applied:
+        for block in result.created:
+            logger.info(f"Created '{block.title}'.")
+        for block in result.skipped:
+            logger.info(f"Skipped '{block.title}': already scheduled.")
+    else:
+        logger.info("Dry run: nothing was written. Pass --apply to create these events.")
 
-        token, projectId = get_github_auth(settings)
-        taskSource = GitHubProjectsTaskSource(token, projectId)
-        projectItems = taskSource.list_work_items()
 
-        plan = schedule(projectItems, busy_blocks, window)
-        existing_todo_markers = sink.list_scheduled_todo_markers()
+def run_authorize(args: argparse.Namespace) -> int:
+    settings = load_settings()
+    authorize_credentials(settings)
+    logger.info("Google Calendar/Tasks authorisation complete.")
+    return 0
 
-        for task in plan.scheduled:
-            if not (
-                task.source
-                and task.source_id
-                and sink.has_scheduled_event(task.source, task.source_id, task.start)
-            ):
-                event = build_event(task, settings)
-                sink.create_event(event)
 
-            for index, todo in enumerate(build_todos(task)):
-                marker = todo_marker(task.source, task.source_id, index)
-                if marker and marker in existing_todo_markers:
-                    continue
-                sink.create_todo(todo)
-                if marker:
-                    existing_todo_markers.add(marker)
+def run_server(args: argparse.Namespace) -> int:
+    logger.info("The MCP server is not implemented yet.")
+    return 1
 
-            logger.info(
-                f"Task '{task.title}' scheduled from {task.start} to {task.end} with priority {task.priority} and size {task.size}, estimate: {task.estimate} hours."
-            )
 
+def run_sync_command(args: argparse.Namespace) -> int:
+    settings = load_settings()
+    overrides = {}
+    if args.working_day_start:
+        overrides["working_day_start"] = args.working_day_start
+    if args.working_day_end:
+        overrides["working_day_end"] = args.working_day_end
+    if overrides:
+        settings = replace(settings, **overrides)
+
+    window = build_window(settings, args.start, args.end)
+    task_source, calendar_sink = build_integrations(settings)
+    result = run_sync(task_source, calendar_sink, window, settings, apply=args.apply)
+    report_sync_result(result)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="cal-auto-python")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    authorize_parser = subparsers.add_parser(
+        "authorize", help="Run the one-off Google Calendar/Tasks authorisation flow."
+    )
+    authorize_parser.set_defaults(func=run_authorize)
+
+    server_parser = subparsers.add_parser("server", help="Run the MCP server.")
+    server_parser.set_defaults(func=run_server)
+
+    sync_parser = subparsers.add_parser(
+        "sync", help="Fetch work items, plan a schedule, and create calendar events/tasks."
+    )
+    sync_parser.add_argument("--start", help="First day to schedule, as YYYY-MM-DD.")
+    sync_parser.add_argument("--end", help="Last day to schedule, as YYYY-MM-DD.")
+    sync_parser.add_argument("--working-day-start", help="Working day start time, as HH:MM.")
+    sync_parser.add_argument("--working-day-end", help="Working day end time, as HH:MM.")
+    sync_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Create the planned events and tasks. Without this flag, sync only previews the plan.",
+    )
+    sync_parser.set_defaults(func=run_sync_command)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.func(args)
     except HttpError as error:
         logger.error(f"An error occurred: {error}")
     except AutoCalendarError as error:
         logger.error(f"{error.args[0]} Hint: {error.hint}")
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/sync.py
+++ b/src/sync.py
@@ -1,0 +1,71 @@
+"""End-to-end sync operation: fetch, plan, and (optionally) apply to the calendar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .dtos.schedule import ScheduleWindow, ScheduledBlock, SchedulePlan, UnscheduledItem
+from .providers.calendar_sink import CalendarSink
+from .providers.google_calendar_sink import build_event, build_todos, todo_marker
+from .providers.task_source import TaskSource
+from .scheduler import schedule
+from .settings import Settings
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    plan: SchedulePlan
+    created: list[ScheduledBlock] = field(default_factory=list)
+    skipped: list[ScheduledBlock] = field(default_factory=list)
+    unscheduled: list[UnscheduledItem] = field(default_factory=list)
+    applied: bool = False
+
+    @property
+    def scheduled(self) -> list[ScheduledBlock]:
+        return self.plan.scheduled
+
+
+def run_sync(
+    task_source: TaskSource,
+    calendar_sink: CalendarSink,
+    window: ScheduleWindow,
+    settings: Settings,
+    apply: bool = False,
+) -> SyncResult:
+    work_items = task_source.list_work_items(settings.schedulable_statuses)
+    busy_blocks = calendar_sink.list_busy_blocks(window)
+
+    plan = schedule(work_items, busy_blocks, window)
+
+    created: list[ScheduledBlock] = []
+    skipped: list[ScheduledBlock] = []
+
+    if not apply:
+        return SyncResult(plan=plan, created=created, skipped=skipped, unscheduled=plan.unscheduled)
+
+    existing_todo_markers = calendar_sink.list_scheduled_todo_markers()
+
+    for task in plan.scheduled:
+        already_scheduled = (
+            task.source
+            and task.source_id
+            and calendar_sink.has_scheduled_event(task.source, task.source_id, task.start)
+        )
+        if already_scheduled:
+            skipped.append(task)
+        else:
+            event = build_event(task, settings)
+            calendar_sink.create_event(event)
+            created.append(task)
+
+        for index, todo in enumerate(build_todos(task)):
+            marker = todo_marker(task.source, task.source_id, index)
+            if marker and marker in existing_todo_markers:
+                continue
+            calendar_sink.create_todo(todo)
+            if marker:
+                existing_todo_markers.add(marker)
+
+    return SyncResult(
+        plan=plan, created=created, skipped=skipped, unscheduled=plan.unscheduled, applied=True
+    )

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,127 @@
+from dataclasses import replace
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from src.dtos.schedule import ScheduleWindow
+from src.dtos.work_item import Priority, Size, WorkItem
+from src.providers.calendar_sink import CalendarSink
+from src.providers.task_source import TaskSource
+from src.settings import load_settings
+from src.sync import run_sync
+
+TZ = ZoneInfo("Europe/Lisbon")
+
+
+class StubTaskSource(TaskSource):
+    def __init__(self, items):
+        self.items = items
+
+    def list_work_items(self, statuses=None):
+        if statuses is None:
+            return self.items
+        wanted = set(statuses)
+        return [item for item in self.items if item.status in wanted]
+
+
+class StubCalendarSink(CalendarSink):
+    def __init__(self, busy_blocks=None, scheduled_identities=None, todo_markers=None):
+        self.busy_blocks = busy_blocks or []
+        self.scheduled_identities = scheduled_identities or set()
+        self.todo_markers = set(todo_markers or set())
+        self.created_events = []
+        self.created_todos = []
+
+    def list_busy_blocks(self, window):
+        return self.busy_blocks
+
+    def create_event(self, event):
+        self.created_events.append(event)
+        return {}
+
+    def create_todo(self, task):
+        self.created_todos.append(task)
+        return {}
+
+    def has_scheduled_event(self, source, source_id, start):
+        return (source, source_id, start) in self.scheduled_identities
+
+    def list_scheduled_todo_markers(self):
+        return self.todo_markers
+
+
+def _settings():
+    return load_settings(
+        {
+            "CAL_AUTO_TIMEZONE": "Europe/Lisbon",
+            "GITHUB_TOKEN": "token",
+            "GITHUB_PROJECT_ID": "project",
+        }
+    )
+
+
+def _window():
+    return ScheduleWindow(
+        start=datetime(2026, 8, 17, 9, 0, tzinfo=TZ),
+        end=datetime(2026, 8, 17, 17, 0, tzinfo=TZ),
+    )
+
+
+def _work_item(item_id, title):
+    return WorkItem(
+        id=item_id,
+        source="github",
+        title=title,
+        priority=Priority.P1,
+        size=Size.S,
+        status="Backlog",
+        tasks=["do the thing"],
+    )
+
+
+def test_dry_run_plans_without_writing():
+    task_source = StubTaskSource([_work_item("1", "Write docs")])
+    calendar_sink = StubCalendarSink()
+
+    result = run_sync(task_source, calendar_sink, _window(), _settings(), apply=False)
+
+    assert not result.applied
+    assert len(result.plan.scheduled) == 1
+    assert result.created == []
+    assert result.skipped == []
+    assert calendar_sink.created_events == []
+    assert calendar_sink.created_todos == []
+
+
+def test_apply_creates_new_items_and_skips_existing():
+    task_source = StubTaskSource([_work_item("1", "Write docs"), _work_item("2", "Ship it")])
+    calendar_sink = StubCalendarSink()
+
+    dry_run = run_sync(task_source, calendar_sink, _window(), _settings(), apply=False)
+    already_scheduled_block = dry_run.plan.scheduled[0]
+    calendar_sink.scheduled_identities = {
+        (
+            already_scheduled_block.source,
+            already_scheduled_block.source_id,
+            already_scheduled_block.start,
+        )
+    }
+
+    result = run_sync(task_source, calendar_sink, _window(), _settings(), apply=True)
+
+    assert result.applied
+    assert len(result.created) == 1
+    assert len(result.skipped) == 1
+    assert len(calendar_sink.created_events) == 1
+    assert len(calendar_sink.created_todos) == 2
+
+
+def test_unscheduled_items_are_reported():
+    huge_item = replace(_work_item("1", "Too big"), size=Size.XL, estimate=100.0)
+    task_source = StubTaskSource([huge_item])
+    calendar_sink = StubCalendarSink()
+
+    result = run_sync(task_source, calendar_sink, _window(), _settings(), apply=False)
+
+    assert result.plan.scheduled != []
+    assert len(result.unscheduled) == 1
+    assert result.unscheduled[0].work_item is huge_item


### PR DESCRIPTION
## What changed

`src/main.py` no longer runs a fixed two-day schedule against hardcoded dates. It's now an argparse
CLI with three subcommands: `authorize` (one-off Google OAuth setup), `sync` (fetch, plan, and
optionally apply), and `server` (placeholder until the MCP server exists). `sync` accepts
`--start`/`--end` dates and `--working-day-start`/`--working-day-end` overrides.

The fetch/plan/skip-existing/create sequence that used to live only in `main()` is now
`run_sync()` in `src/sync.py`, returning a `SyncResult` with the plan plus what was created,
skipped as already-scheduled, and left unscheduled. `build_integrations()` in `main.py` is the one
place that decides which `TaskSource`/`CalendarSink` implementations to construct.

## Why / Context

The old script had no way to say which days to schedule or preview before writing to a real
calendar — you had to edit the source. Previewing is now the default; `sync` only applies with
`--apply`. Pulling the sequence out into `run_sync()` also means the MCP server (DAN-19) can call
the same operation instead of re-implementing it against the same providers.

## How to test

```bash
uv run cal-auto-python authorize
uv run cal-auto-python sync                                   # preview only
uv run cal-auto-python sync --start 2026-08-17 --end 2026-08-21 --apply
```

`uv run python -m pytest -q tests/test_sync.py` covers `run_sync()` with stand-in task source and
calendar sink, no network involved.

## Checklist

- [x] `sync` previewed against a real GitHub project and Google account before merging