### PR TITLE
Add read-only calendar, todo, and tracker listing tools

### DIFF
--- a/src/dtos/calendar_entry.py
+++ b/src/dtos/calendar_entry.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class CalendarEntryDTO:
+    title: str
+    start: datetime
+    end: datetime
+    all_day: bool = False
+
+
+@dataclass(frozen=True)
+class TodoItemDTO:
+    title: str
+    status: str
+    notes: Optional[str] = None
+    due: Optional[str] = None

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -1,0 +1,26 @@
+"""Wiring for the real GitHub/Google integrations behind the provider seams."""
+
+from __future__ import annotations
+
+from .auth import get_calendar_service, get_tasks_service, load_credentials
+from .ghub import GitHubProjectsTaskSource, get_github_auth
+from .providers.calendar_sink import CalendarSink
+from .providers.google_calendar_sink import GoogleCalendarSink
+from .providers.task_source import TaskSource
+from .settings import Settings
+
+
+def build_task_source(settings: Settings) -> TaskSource:
+    token, project_id = get_github_auth(settings)
+    return GitHubProjectsTaskSource(token, project_id)
+
+
+def build_calendar_sink(settings: Settings) -> CalendarSink:
+    creds = load_credentials(settings)
+    calendar_service = get_calendar_service(creds)
+    tasks_service = get_tasks_service(creds)
+    return GoogleCalendarSink(calendar_service, tasks_service, settings)
+
+
+def build_integrations(settings: Settings) -> tuple[TaskSource, CalendarSink]:
+    return build_task_source(settings), build_calendar_sink(settings)

--- a/src/main.py
+++ b/src/main.py
@@ -6,29 +6,14 @@ from zoneinfo import ZoneInfo
 
 from googleapiclient.errors import HttpError
 
-from .auth import authorize_credentials, get_calendar_service, get_tasks_service, load_credentials
+from .auth import authorize_credentials
 from .dtos.schedule import ScheduleWindow
 from .errors import AutoCalendarError
-from .ghub import GitHubProjectsTaskSource, get_github_auth
+from .integrations import build_integrations
 from .logger import logger
 from .mcp_server import build_server
-from .providers.calendar_sink import CalendarSink
-from .providers.google_calendar_sink import GoogleCalendarSink
-from .providers.task_source import TaskSource
 from .settings import Settings, load_settings
 from .sync import SyncResult, run_sync
-
-
-def build_integrations(settings: Settings) -> tuple[TaskSource, CalendarSink]:
-    creds = load_credentials(settings)
-    calendar_service = get_calendar_service(creds)
-    tasks_service = get_tasks_service(creds)
-    calendar_sink = GoogleCalendarSink(calendar_service, tasks_service, settings)
-
-    token, project_id = get_github_auth(settings)
-    task_source = GitHubProjectsTaskSource(token, project_id)
-
-    return task_source, calendar_sink
 
 
 def build_window(

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -90,7 +90,8 @@ def build_server(
         name="list_calendar_entries",
         description=(
             "List calendar entries (events and all-day items) between two dates, inclusive. "
-            "Dates are given as YYYY-MM-DD. Does not page through very large result sets. "
+            "Dates are given as YYYY-MM-DD. Returns every matching entry in a single response; "
+            "there is no cursor for paging through the result. "
             "Requires Google Calendar authorisation; call `status` first if unsure."
         ),
         annotations=READ_ONLY,
@@ -145,6 +146,11 @@ def _list_calendar_entries(
 ) -> CalendarEntries:
     window_start = _parse_date(settings, "start", start)
     window_end = _parse_date(settings, "end", end) + timedelta(days=1)
+    if window_end <= window_start:
+        raise ConfigurationError(
+            f"end date {end!r} is before start date {start!r}",
+            hint="Pass an end date on or after the start date.",
+        )
     window = ScheduleWindow(start=window_start, end=window_end)
 
     calendar_sink = calendar_sink_factory(settings)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -3,15 +3,27 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta
+from typing import Callable, List, Optional
+from zoneinfo import ZoneInfo
+
 from pydantic import BaseModel
 
 from google.oauth2.credentials import Credentials
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from .auth import SCOPES
+from .dtos.schedule import ScheduleWindow
+from .errors import ConfigurationError
+from .integrations import build_calendar_sink, build_task_source
+from .providers.calendar_sink import CalendarSink
+from .providers.task_source import TaskSource
 from .settings import Settings
 
 SERVER_NAME = "auto-calendar"
+
+READ_ONLY = ToolAnnotations(readOnlyHint=True)
 
 
 class IntegrationStatus(BaseModel):
@@ -20,7 +32,47 @@ class IntegrationStatus(BaseModel):
     google_calendar_authorized: bool
 
 
-def build_server(settings: Settings) -> FastMCP:
+class CalendarEntry(BaseModel):
+    title: str
+    start: datetime
+    end: datetime
+    all_day: bool
+
+
+class CalendarEntries(BaseModel):
+    entries: List[CalendarEntry]
+
+
+class TodoItem(BaseModel):
+    title: str
+    status: str
+    notes: Optional[str] = None
+    due: Optional[str] = None
+
+
+class TodoList(BaseModel):
+    todos: List[TodoItem]
+
+
+class TrackerItem(BaseModel):
+    id: Optional[str] = None
+    title: Optional[str] = None
+    status: Optional[str] = None
+    priority: Optional[str] = None
+    size: Optional[str] = None
+    assignee: Optional[str] = None
+    estimate: Optional[float] = None
+
+
+class TrackerItems(BaseModel):
+    items: List[TrackerItem]
+
+
+def build_server(
+    settings: Settings,
+    task_source_factory: Callable[[Settings], TaskSource] = build_task_source,
+    calendar_sink_factory: Callable[[Settings], CalendarSink] = build_calendar_sink,
+) -> FastMCP:
     server = FastMCP(SERVER_NAME)
 
     @server.tool(
@@ -29,11 +81,113 @@ def build_server(settings: Settings) -> FastMCP:
             "Report which integrations are configured and whether Google Calendar "
             "authorisation is present. Reveals no secrets."
         ),
+        annotations=READ_ONLY,
     )
     async def status() -> IntegrationStatus:
         return await asyncio.to_thread(_check_status, settings)
 
+    @server.tool(
+        name="list_calendar_entries",
+        description=(
+            "List calendar entries (events and all-day items) between two dates, inclusive. "
+            "Dates are given as YYYY-MM-DD. Does not page through very large result sets. "
+            "Requires Google Calendar authorisation; call `status` first if unsure."
+        ),
+        annotations=READ_ONLY,
+    )
+    async def list_calendar_entries(start: str, end: str) -> CalendarEntries:
+        return await asyncio.to_thread(
+            _list_calendar_entries, settings, calendar_sink_factory, start, end
+        )
+
+    @server.tool(
+        name="list_todos",
+        description=(
+            "List outstanding (not completed) to-do items from the configured Google Tasks "
+            "list. Requires Google authorisation; call `status` first if unsure."
+        ),
+        annotations=READ_ONLY,
+    )
+    async def list_todos() -> TodoList:
+        return await asyncio.to_thread(_list_todos, settings, calendar_sink_factory)
+
+    @server.tool(
+        name="list_tracker_items",
+        description=(
+            "List work items from the GitHub Projects tracker board, optionally restricted "
+            "to the given statuses (e.g. ['Backlog', 'In Progress']). Omit `statuses` to list "
+            "every item on the board. Requires GITHUB_TOKEN/GITHUB_PROJECT_ID to be configured."
+        ),
+        annotations=READ_ONLY,
+    )
+    async def list_tracker_items(statuses: Optional[List[str]] = None) -> TrackerItems:
+        return await asyncio.to_thread(_list_tracker_items, settings, task_source_factory, statuses)
+
     return server
+
+
+def _parse_date(settings: Settings, label: str, value: str) -> datetime:
+    try:
+        date = datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ConfigurationError(
+            f"Invalid {label} date: {value!r}",
+            hint="Use YYYY-MM-DD, e.g. 2026-08-17.",
+        ) from exc
+    return datetime.combine(date, datetime.min.time(), ZoneInfo(settings.timezone))
+
+
+def _list_calendar_entries(
+    settings: Settings,
+    calendar_sink_factory: Callable[[Settings], CalendarSink],
+    start: str,
+    end: str,
+) -> CalendarEntries:
+    window_start = _parse_date(settings, "start", start)
+    window_end = _parse_date(settings, "end", end) + timedelta(days=1)
+    window = ScheduleWindow(start=window_start, end=window_end)
+
+    calendar_sink = calendar_sink_factory(settings)
+    entries = calendar_sink.list_entries(window)
+    return CalendarEntries(
+        entries=[
+            CalendarEntry(title=e.title, start=e.start, end=e.end, all_day=e.all_day)
+            for e in entries
+        ]
+    )
+
+
+def _list_todos(
+    settings: Settings, calendar_sink_factory: Callable[[Settings], CalendarSink]
+) -> TodoList:
+    calendar_sink = calendar_sink_factory(settings)
+    todos = calendar_sink.list_outstanding_todos()
+    return TodoList(
+        todos=[TodoItem(title=t.title, status=t.status, notes=t.notes, due=t.due) for t in todos]
+    )
+
+
+def _list_tracker_items(
+    settings: Settings,
+    task_source_factory: Callable[[Settings], TaskSource],
+    statuses: Optional[List[str]],
+) -> TrackerItems:
+    task_source = task_source_factory(settings)
+    work_items = task_source.list_work_items(statuses)
+    return TrackerItems(
+        items=[
+            TrackerItem(
+                id=item.id,
+                title=item.title,
+                status=item.status,
+                priority=item.priority.name if item.priority is not None else None,
+                size=item.size.name if item.size is not None else None,
+                assignee=item.assignee,
+                estimate=item.estimate,
+            )
+            for item in work_items
+        ]
+    )
 
 
 def _check_status(settings: Settings) -> IntegrationStatus:

--- a/src/providers/calendar_sink.py
+++ b/src/providers/calendar_sink.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import List, Set
 
+from ..dtos.calendar_entry import CalendarEntryDTO, TodoItemDTO
 from ..dtos.event import EventDTO
 from ..dtos.schedule import ScheduleWindow, ScheduledBlock
 from ..dtos.task import TaskDTO
@@ -11,6 +12,14 @@ class CalendarSink(ABC):
     @abstractmethod
     def list_busy_blocks(self, window: ScheduleWindow) -> List[ScheduledBlock]:
         """Return the blocks already occupying the given window."""
+
+    @abstractmethod
+    def list_entries(self, window: ScheduleWindow) -> List[CalendarEntryDTO]:
+        """Return every calendar entry within the given window."""
+
+    @abstractmethod
+    def list_outstanding_todos(self) -> List[TodoItemDTO]:
+        """Return to-do items that have not been completed."""
 
     @abstractmethod
     def create_event(self, event: EventDTO) -> dict:

--- a/src/providers/google_calendar_sink.py
+++ b/src/providers/google_calendar_sink.py
@@ -90,7 +90,7 @@ def event_to_calendar_entry(
             return None
         span_start = datetime.strptime(event_start_date, "%Y-%m-%d").date()
         span_end = datetime.strptime(event_end_date, "%Y-%m-%d").date()
-        if span_start > window.end.date() or span_end <= window.start.date():
+        if span_start >= window.end.date() or span_end <= window.start.date():
             return None
         return CalendarEntryDTO(
             title=title,

--- a/src/providers/google_calendar_sink.py
+++ b/src/providers/google_calendar_sink.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import List, Optional, Set, cast
 from zoneinfo import ZoneInfo
 
+from ..dtos.calendar_entry import CalendarEntryDTO, TodoItemDTO
 from ..dtos.event import EventDTO
 from ..dtos.schedule import ScheduledBlock, ScheduleWindow
 from ..dtos.task import TaskDTO
@@ -72,6 +73,48 @@ def event_to_busy_block(
         end=event_end,
         status="Backlog",
     )
+
+
+def event_to_calendar_entry(
+    event: dict, window: ScheduleWindow, settings: Settings
+) -> Optional[CalendarEntryDTO]:
+    start = event.get("start", {})
+    end = event.get("end", {})
+    local_timezone = ZoneInfo(settings.timezone)
+    title = cast(str, event.get("summary", ""))
+
+    if "dateTime" not in start or "dateTime" not in end:
+        event_start_date = start.get("date")
+        event_end_date = end.get("date")
+        if event_start_date is None or event_end_date is None:
+            return None
+        span_start = datetime.strptime(event_start_date, "%Y-%m-%d").date()
+        span_end = datetime.strptime(event_end_date, "%Y-%m-%d").date()
+        if span_start > window.end.date() or span_end <= window.start.date():
+            return None
+        return CalendarEntryDTO(
+            title=title,
+            start=datetime.combine(span_start, datetime.min.time(), local_timezone),
+            end=datetime.combine(span_end, datetime.min.time(), local_timezone),
+            all_day=True,
+        )
+
+    event_start = datetime.fromisoformat(start["dateTime"]).astimezone(local_timezone)
+    event_end = datetime.fromisoformat(end["dateTime"]).astimezone(local_timezone)
+    if event_start >= window.end or event_end <= window.start:
+        return None
+
+    return CalendarEntryDTO(title=title, start=event_start, end=event_end, all_day=False)
+
+
+def task_to_todo_item(task: dict) -> Optional[TodoItemDTO]:
+    status = task.get("status", "needsAction")
+    if status == "completed":
+        return None
+    title = task.get("title")
+    if not title:
+        return None
+    return TodoItemDTO(title=title, status=status, notes=task.get("notes"), due=task.get("due"))
 
 
 def _merge_busy_blocks(blocks: List[ScheduledBlock]) -> List[ScheduledBlock]:
@@ -179,6 +222,39 @@ class GoogleCalendarSink(CalendarSink):
             if block is not None
         ]
         return _merge_busy_blocks(blocks)
+
+    def list_entries(self, window: ScheduleWindow) -> List[CalendarEntryDTO]:
+        entries = [
+            entry
+            for entry in (
+                event_to_calendar_entry(event, window, self.settings)
+                for event in self.list_events(window)
+            )
+            if entry is not None
+        ]
+        return sorted(entries, key=lambda entry: entry.start)
+
+    def list_outstanding_todos(self) -> List[TodoItemDTO]:
+        todos: List[TodoItemDTO] = []
+        page_token = None
+        while True:
+            result = (
+                self.tasks_service.tasks()
+                .list(
+                    tasklist=self.settings.task_list_id,
+                    showCompleted=False,
+                    showHidden=False,
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+            for task in result.get("items", []):
+                todo = task_to_todo_item(task)
+                if todo is not None:
+                    todos.append(todo)
+            page_token = result.get("nextPageToken")
+            if not page_token:
+                return todos
 
     def create_event(self, event: EventDTO) -> dict:
         return (

--- a/tests/test_google_calendar_sink.py
+++ b/tests/test_google_calendar_sink.py
@@ -13,6 +13,8 @@ from src.providers.google_calendar_sink import (
     build_todos,
     event_color_id,
     event_to_busy_block,
+    event_to_calendar_entry,
+    task_to_todo_item,
     todo_marker,
 )
 from src.settings import load_settings
@@ -457,3 +459,168 @@ def test_applying_the_same_plan_twice_creates_each_event_and_todo_once(tmp_path,
 
     assert len(created_events) == 1
     assert len(created_todos) == 2
+
+
+def entries_window():
+    return ScheduleWindow(
+        start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 2, tzinfo=timezone.utc),
+    )
+
+
+def test_event_to_calendar_entry_converts_a_zero_offset_timed_event(tmp_path):
+    event = {
+        "summary": "Meeting",
+        "start": {"dateTime": "2024-01-01T10:00:00+00:00"},
+        "end": {"dateTime": "2024-01-01T11:00:00+00:00"},
+    }
+
+    entry = event_to_calendar_entry(event, entries_window(), settings(tmp_path))
+
+    assert entry.title == "Meeting"
+    assert entry.start == datetime(2024, 1, 1, 10, tzinfo=timezone.utc)
+    assert entry.end == datetime(2024, 1, 1, 11, tzinfo=timezone.utc)
+    assert entry.all_day is False
+
+
+def test_event_to_calendar_entry_converts_a_non_zero_offset_event_into_the_configured_timezone(
+    tmp_path,
+):
+    event = {
+        "summary": "Meeting",
+        "start": {"dateTime": "2024-01-01T10:00:00+01:00"},
+        "end": {"dateTime": "2024-01-01T11:00:00+01:00"},
+    }
+
+    entry = event_to_calendar_entry(event, entries_window(), settings(tmp_path))
+
+    assert entry.start == datetime(2024, 1, 1, 9, tzinfo=timezone.utc)
+    assert entry.end == datetime(2024, 1, 1, 10, tzinfo=timezone.utc)
+
+
+def test_event_to_calendar_entry_excludes_a_timed_event_ending_exactly_at_window_start(tmp_path):
+    event = {
+        "summary": "Just before",
+        "start": {"dateTime": "2023-12-31T22:00:00+00:00"},
+        "end": {"dateTime": "2024-01-01T00:00:00+00:00"},
+    }
+
+    assert event_to_calendar_entry(event, entries_window(), settings(tmp_path)) is None
+
+
+def test_event_to_calendar_entry_excludes_a_timed_event_starting_exactly_at_window_end(tmp_path):
+    event = {
+        "summary": "Just after",
+        "start": {"dateTime": "2024-01-02T00:00:00+00:00"},
+        "end": {"dateTime": "2024-01-02T01:00:00+00:00"},
+    }
+
+    assert event_to_calendar_entry(event, entries_window(), settings(tmp_path)) is None
+
+
+def test_event_to_calendar_entry_includes_all_day_events_by_default(tmp_path):
+    event = {"summary": "Holiday", "start": {"date": "2024-01-01"}, "end": {"date": "2024-01-02"}}
+
+    entry = event_to_calendar_entry(event, entries_window(), settings(tmp_path))
+
+    assert entry.title == "Holiday"
+    assert entry.all_day is True
+    assert entry.start == datetime(2024, 1, 1, tzinfo=timezone.utc)
+    assert entry.end == datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+
+def test_event_to_calendar_entry_excludes_an_all_day_event_starting_on_the_exclusive_window_end(
+    tmp_path,
+):
+    event = {"summary": "Later", "start": {"date": "2024-01-02"}, "end": {"date": "2024-01-03"}}
+
+    assert event_to_calendar_entry(event, entries_window(), settings(tmp_path)) is None
+
+
+def test_event_to_calendar_entry_excludes_an_all_day_event_ending_exactly_at_window_start(
+    tmp_path,
+):
+    event = {"summary": "Earlier", "start": {"date": "2023-12-31"}, "end": {"date": "2024-01-01"}}
+
+    assert event_to_calendar_entry(event, entries_window(), settings(tmp_path)) is None
+
+
+def test_event_to_calendar_entry_returns_none_for_a_malformed_all_day_payload(tmp_path):
+    event = {"summary": "Broken", "start": {"date": None}, "end": {}}
+
+    assert event_to_calendar_entry(event, entries_window(), settings(tmp_path)) is None
+
+
+def test_task_to_todo_item_converts_an_outstanding_task():
+    task = {"title": "Write report", "status": "needsAction", "notes": "due soon", "due": "x"}
+
+    todo = task_to_todo_item(task)
+
+    assert todo.title == "Write report"
+    assert todo.status == "needsAction"
+    assert todo.notes == "due soon"
+    assert todo.due == "x"
+
+
+def test_task_to_todo_item_excludes_completed_tasks():
+    task = {"title": "Done already", "status": "completed"}
+
+    assert task_to_todo_item(task) is None
+
+
+def test_task_to_todo_item_excludes_tasks_without_a_title():
+    task = {"status": "needsAction"}
+
+    assert task_to_todo_item(task) is None
+
+
+def test_list_entries_returns_entries_sorted_by_start_across_pages(tmp_path, mocker):
+    service = mocker.Mock()
+    service.events.return_value.list.return_value.execute.side_effect = [
+        {
+            "items": [
+                {
+                    "summary": "Second",
+                    "start": {"dateTime": "2024-01-01T12:00:00+00:00"},
+                    "end": {"dateTime": "2024-01-01T13:00:00+00:00"},
+                }
+            ],
+            "nextPageToken": "page-2",
+        },
+        {
+            "items": [
+                {
+                    "summary": "First",
+                    "start": {"dateTime": "2024-01-01T09:00:00+00:00"},
+                    "end": {"dateTime": "2024-01-01T10:00:00+00:00"},
+                }
+            ]
+        },
+    ]
+    sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
+
+    entries = sink.list_entries(entries_window())
+
+    assert [e.title for e in entries] == ["First", "Second"]
+
+
+def test_list_outstanding_todos_filters_completed_tasks_across_pages(tmp_path, mocker):
+    service = mocker.Mock()
+    service.tasks.return_value.list.return_value.execute.side_effect = [
+        {
+            "items": [
+                {"title": "Open task", "status": "needsAction"},
+                {"title": "Done task", "status": "completed"},
+            ],
+            "nextPageToken": "page-2",
+        },
+        {"items": [{"title": "Another open task", "status": "needsAction"}]},
+    ]
+    sink = GoogleCalendarSink(mocker.Mock(), service, settings(tmp_path))
+
+    todos = sink.list_outstanding_todos()
+
+    assert [t.title for t in todos] == ["Open task", "Another open task"]
+    _, kwargs = service.tasks.return_value.list.call_args_list[0]
+    assert kwargs["tasklist"] == "@default"
+    assert kwargs["showCompleted"] is False

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,13 +2,19 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timezone
 
 import pytest
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.shared.memory import create_connected_server_and_client_session
 
+from src.dtos.calendar_entry import CalendarEntryDTO, TodoItemDTO
+from src.dtos.work_item import Priority, Size, WorkItem
+from src.errors import AuthorizationError
 from src.mcp_server import build_server
+from src.providers.calendar_sink import CalendarSink
+from src.providers.task_source import TaskSource
 from src.settings import load_settings
 
 
@@ -22,6 +28,200 @@ def settings(tmp_path):
             "GITHUB_PROJECT_ID": "project",
         }
     )
+
+
+class StubTaskSource(TaskSource):
+    def __init__(self, items):
+        self.items = items
+
+    def list_work_items(self, statuses=None):
+        if statuses is None:
+            return self.items
+        wanted = set(statuses)
+        return [item for item in self.items if item.status in wanted]
+
+
+class StubCalendarSink(CalendarSink):
+    def __init__(self, entries=None, todos=None):
+        self.entries = entries or []
+        self.todos = todos or []
+
+    def list_busy_blocks(self, window):
+        return []
+
+    def list_entries(self, window):
+        return self.entries
+
+    def list_outstanding_todos(self):
+        return self.todos
+
+    def create_event(self, event):
+        raise NotImplementedError
+
+    def create_todo(self, task):
+        raise NotImplementedError
+
+    def has_scheduled_event(self, source, source_id, start):
+        raise NotImplementedError
+
+    def list_scheduled_todo_markers(self):
+        raise NotImplementedError
+
+
+class FailingTaskSource(TaskSource):
+    def list_work_items(self, statuses=None):
+        raise AuthorizationError(
+            "GitHub token is invalid",
+            hint="Run cal-auto-python authorize before starting the server.",
+        )
+
+
+class FailingCalendarSink(CalendarSink):
+    def list_busy_blocks(self, window):
+        raise NotImplementedError
+
+    def list_entries(self, window):
+        raise AuthorizationError(
+            "Google account has not been authorised",
+            hint="Run cal-auto-python authorize before starting the server.",
+        )
+
+    def list_outstanding_todos(self):
+        raise AuthorizationError(
+            "Google account has not been authorised",
+            hint="Run cal-auto-python authorize before starting the server.",
+        )
+
+    def create_event(self, event):
+        raise NotImplementedError
+
+    def create_todo(self, task):
+        raise NotImplementedError
+
+    def has_scheduled_event(self, source, source_id, start):
+        raise NotImplementedError
+
+    def list_scheduled_todo_markers(self):
+        raise NotImplementedError
+
+
+@pytest.mark.anyio
+async def test_list_calendar_entries_returns_structured_entries(settings):
+    calendar_sink = StubCalendarSink(
+        entries=[
+            CalendarEntryDTO(
+                title="Standup",
+                start=datetime(2026, 8, 17, 9, tzinfo=timezone.utc),
+                end=datetime(2026, 8, 17, 9, 30, tzinfo=timezone.utc),
+                all_day=False,
+            )
+        ]
+    )
+    server = build_server(settings, calendar_sink_factory=lambda _settings: calendar_sink)
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        tool = next(
+            t for t in (await client.list_tools()).tools if t.name == "list_calendar_entries"
+        )
+        assert tool.annotations.readOnlyHint is True
+
+        result = await client.call_tool(
+            "list_calendar_entries", {"start": "2026-08-17", "end": "2026-08-17"}
+        )
+
+    assert result.structuredContent["entries"] == [
+        {
+            "title": "Standup",
+            "start": "2026-08-17T09:00:00Z",
+            "end": "2026-08-17T09:30:00Z",
+            "all_day": False,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_list_todos_returns_structured_todos(settings):
+    calendar_sink = StubCalendarSink(
+        todos=[TodoItemDTO(title="Write report", status="needsAction", notes="due soon")]
+    )
+    server = build_server(settings, calendar_sink_factory=lambda _settings: calendar_sink)
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        tool = next(t for t in (await client.list_tools()).tools if t.name == "list_todos")
+        assert tool.annotations.readOnlyHint is True
+
+        result = await client.call_tool("list_todos", {})
+
+    assert result.structuredContent["todos"] == [
+        {"title": "Write report", "status": "needsAction", "notes": "due soon", "due": None}
+    ]
+
+
+@pytest.mark.anyio
+async def test_list_tracker_items_filters_by_status(settings):
+    task_source = StubTaskSource(
+        [
+            WorkItem(id="1", title="Ship it", status="Backlog", priority=Priority.P1, size=Size.S),
+            WorkItem(id="2", title="Done thing", status="Done"),
+        ]
+    )
+    server = build_server(settings, task_source_factory=lambda _settings: task_source)
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        tool = next(t for t in (await client.list_tools()).tools if t.name == "list_tracker_items")
+        assert tool.annotations.readOnlyHint is True
+
+        result = await client.call_tool("list_tracker_items", {"statuses": ["Backlog"]})
+
+    assert [item["title"] for item in result.structuredContent["items"]] == ["Ship it"]
+    assert result.structuredContent["items"][0]["priority"] == "P1"
+
+
+@pytest.mark.anyio
+async def test_list_tracker_items_returns_everything_without_a_status_filter(settings):
+    task_source = StubTaskSource(
+        [
+            WorkItem(id="1", title="Ship it", status="Backlog"),
+            WorkItem(id="2", title="Done thing", status="Done"),
+        ]
+    )
+    server = build_server(settings, task_source_factory=lambda _settings: task_source)
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        result = await client.call_tool("list_tracker_items", {})
+
+    assert [item["title"] for item in result.structuredContent["items"]] == [
+        "Ship it",
+        "Done thing",
+    ]
+
+
+@pytest.mark.anyio
+async def test_list_calendar_entries_surfaces_the_authorization_hint_when_unauthorized(settings):
+    server = build_server(settings, calendar_sink_factory=lambda _settings: FailingCalendarSink())
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        result = await client.call_tool(
+            "list_calendar_entries", {"start": "2026-08-17", "end": "2026-08-17"}
+        )
+
+    assert result.isError is True
+    message = result.content[0].text
+    assert "Google account has not been authorised" in message
+    assert "cal-auto-python authorize" in message
+
+
+@pytest.mark.anyio
+async def test_list_tracker_items_surfaces_the_authorization_hint_when_unauthorized(settings):
+    server = build_server(settings, task_source_factory=lambda _settings: FailingTaskSource())
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        result = await client.call_tool("list_tracker_items", {})
+
+    assert result.isError is True
+    message = result.content[0].text
+    assert "GitHub token is invalid" in message
+    assert "cal-auto-python authorize" in message
 
 
 @pytest.mark.anyio

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -225,6 +225,19 @@ async def test_list_tracker_items_surfaces_the_authorization_hint_when_unauthori
 
 
 @pytest.mark.anyio
+async def test_list_calendar_entries_rejects_an_end_date_before_the_start_date(settings):
+    server = build_server(settings, calendar_sink_factory=lambda _settings: StubCalendarSink())
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        result = await client.call_tool(
+            "list_calendar_entries", {"start": "2026-08-17", "end": "2026-08-16"}
+        )
+
+    assert result.isError is True
+    assert "end date" in result.content[0].text
+
+
+@pytest.mark.anyio
 async def test_status_tool_is_listed_with_correct_schema(settings):
     async with create_connected_server_and_client_session(
         build_server(settings)._mcp_server

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -34,6 +34,12 @@ class StubCalendarSink(CalendarSink):
     def list_busy_blocks(self, window):
         return self.busy_blocks
 
+    def list_entries(self, window):
+        return []
+
+    def list_outstanding_todos(self):
+        return []
+
     def create_event(self, event):
         self.created_events.append(event)
         return {}


### PR DESCRIPTION
## What changed
Adds three read-only MCP tools alongside the existing `status` tool: `list_calendar_entries` (events/all-day items in a date range), `list_todos` (outstanding Google Tasks), and `list_tracker_items` (GitHub Projects work items, optionally filtered by status). All four tools are now marked `readOnlyHint`. `CalendarSink` gains `list_entries`/`list_outstanding_todos`, implemented in `GoogleCalendarSink` alongside the existing busy-block logic. `TaskSource.list_work_items` is reused directly for the tracker tool. Provider construction was split out of `main.py` into `src/integrations.py` (`build_task_source`/`build_calendar_sink`), and `build_server` now accepts factory overrides so tests can inject stand-ins instead of hitting real Google/GitHub APIs.

## Why / Context
DAN-20 asks for the assistant to be able to look at the calendar, to-do list, and tracker board before any capability that writes is added. These are the safe, read-only surfaces, so they're the right place to settle response shape and description wording. Errors (e.g. missing Google authorisation) must reach the calling client as the existing `AutoCalendarError` message and hint rather than a stack trace — this falls out for free because FastMCP wraps tool exceptions into an error `CallToolResult` whose text includes `str(exception)`, which already embeds the hint.

## How to test
`uv run python -m pytest -q` covers all three tools end-to-end through an in-memory MCP client with stand-in `TaskSource`/`CalendarSink` implementations, including a case asserting the authorisation hint text survives to the client. Manually: run `cal-auto-python server`, connect with any MCP client, call `list_calendar_entries` with `start`/`end` as `YYYY-MM-DD`, `list_todos`, and `list_tracker_items` (with or without `statuses`).

## Checklist
- [x] `uv run python -m ruff check .`
- [x] `uv run python -m ruff format --check .`
- [x] `uv run python -m pytest -q`
- [x] `uv run python -m mypy src tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only tools for viewing calendar entries, outstanding to-dos, and tracker items.
  * Calendar results support date-range filtering, time zones, all-day events, and structured responses.
  * Outstanding to-dos include notes and due dates while excluding completed or untitled tasks.
  * Added clear authorization and invalid-date error handling.
* **Bug Fixes**
  * Improved filtering and sorting of calendar entries and to-do results.
  * Standardized integration setup for calendar and task providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->