### PR TITLE
Add direct calendar and todo creation tools

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -14,7 +14,9 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
 from .auth import SCOPES
+from .dtos.event import EventDTO
 from .dtos.schedule import ScheduleWindow
+from .dtos.task import TaskDTO
 from .errors import ConfigurationError
 from .integrations import build_calendar_sink, build_task_source
 from .providers.calendar_sink import CalendarSink
@@ -24,6 +26,9 @@ from .settings import Settings
 SERVER_NAME = "auto-calendar"
 
 READ_ONLY = ToolAnnotations(readOnlyHint=True)
+WRITES_EXTERNAL_SYSTEM = ToolAnnotations(
+    readOnlyHint=False, idempotentHint=False, destructiveHint=False, openWorldHint=True
+)
 
 
 class IntegrationStatus(BaseModel):
@@ -124,6 +129,52 @@ def build_server(
     async def list_tracker_items(statuses: Optional[List[str]] = None) -> TrackerItems:
         return await asyncio.to_thread(_list_tracker_items, settings, task_source_factory, statuses)
 
+    @server.tool(
+        name="create_calendar_entry",
+        description=(
+            "Create exactly one calendar entry with a summary, start, end, and optional "
+            "description and attendee email addresses. Start and end use ISO 8601 values; "
+            "a naive value is interpreted in the supplied IANA timezone. This writes to "
+            "Google Calendar and does not schedule or deduplicate entries."
+        ),
+        annotations=WRITES_EXTERNAL_SYSTEM,
+    )
+    async def create_calendar_entry(
+        summary: str,
+        start: str,
+        end: str,
+        timezone: str,
+        description: Optional[str] = None,
+        attendees: Optional[List[str]] = None,
+    ) -> dict:
+        return await asyncio.to_thread(
+            _create_calendar_entry,
+            settings,
+            calendar_sink_factory,
+            summary,
+            start,
+            end,
+            timezone,
+            description,
+            attendees,
+        )
+
+    @server.tool(
+        name="create_todo",
+        description=(
+            "Create exactly one to-do with a title and optional note and due date. "
+            "The due date must be an ISO 8601 value when supplied. This writes to Google "
+            "Tasks and does not deduplicate items."
+        ),
+        annotations=WRITES_EXTERNAL_SYSTEM,
+    )
+    async def create_todo(
+        title: str, note: Optional[str] = None, due: Optional[str] = None
+    ) -> dict:
+        return await asyncio.to_thread(
+            _create_todo, settings, calendar_sink_factory, title, note, due
+        )
+
     return server
 
 
@@ -194,6 +245,73 @@ def _list_tracker_items(
             for item in work_items
         ]
     )
+
+
+def _parse_datetime(value: str, label: str, timezone: str) -> datetime:
+    try:
+        zone = ZoneInfo(timezone)
+    except Exception as exc:
+        raise ConfigurationError(
+            f"Unknown timezone: {timezone!r}",
+            hint="Pass a valid IANA timezone name, e.g. Europe/Lisbon.",
+        ) from exc
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ConfigurationError(
+            f"Invalid {label} datetime: {value!r}",
+            hint="Use an ISO 8601 datetime, e.g. 2026-08-18T09:00:00.",
+        ) from exc
+    return parsed.replace(tzinfo=zone) if parsed.tzinfo is None else parsed
+
+
+def _create_calendar_entry(
+    settings: Settings,
+    calendar_sink_factory: Callable[[Settings], CalendarSink],
+    summary: str,
+    start: str,
+    end: str,
+    timezone: str,
+    description: Optional[str],
+    attendees: Optional[List[str]],
+) -> dict:
+    if not summary.strip():
+        raise ConfigurationError("Calendar summary cannot be empty", hint="Pass a summary.")
+    start_dt = _parse_datetime(start, "start", timezone)
+    end_dt = _parse_datetime(end, "end", timezone)
+    if end_dt <= start_dt:
+        raise ConfigurationError(
+            "Calendar entry end must be after its start",
+            hint="Pass an end datetime later than the start datetime.",
+        )
+    event = EventDTO(
+        summary=summary,
+        start={"dateTime": start_dt.isoformat(), "timeZone": timezone},
+        end={"dateTime": end_dt.isoformat(), "timeZone": timezone},
+        description=description,
+        attendees=[{"email": email} for email in (attendees or [])] or None,
+    )
+    return calendar_sink_factory(settings).create_event(event)
+
+
+def _create_todo(
+    settings: Settings,
+    calendar_sink_factory: Callable[[Settings], CalendarSink],
+    title: str,
+    note: Optional[str],
+    due: Optional[str],
+) -> dict:
+    if not title.strip():
+        raise ConfigurationError("To-do title cannot be empty", hint="Pass a title.")
+    if due is not None:
+        try:
+            datetime.fromisoformat(due.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ConfigurationError(
+                f"Invalid due datetime: {due!r}", hint="Use an ISO 8601 datetime."
+            ) from exc
+    task = TaskDTO(kind="tasks#task", title=title, notes=note or "", status="needsAction", due=due)
+    return calendar_sink_factory(settings).create_todo(task)
 
 
 def _check_status(settings: Settings) -> IntegrationStatus:

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -305,7 +305,10 @@ def _create_todo(
         raise ConfigurationError("To-do title cannot be empty", hint="Pass a title.")
     if due is not None:
         try:
-            datetime.fromisoformat(due.replace("Z", "+00:00"))
+            if len(due) == 10:
+                due = datetime.strptime(due, "%Y-%m-%d").isoformat() + "Z"
+            else:
+                datetime.fromisoformat(due.replace("Z", "+00:00"))
         except ValueError as exc:
             raise ConfigurationError(
                 f"Invalid due datetime: {due!r}", hint="Use an ISO 8601 datetime."

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10,6 +10,8 @@ from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.shared.memory import create_connected_server_and_client_session
 
 from src.dtos.calendar_entry import CalendarEntryDTO, TodoItemDTO
+from src.dtos.event import EventDTO
+from src.dtos.task import TaskDTO
 from src.dtos.work_item import Priority, Size, WorkItem
 from src.errors import AuthorizationError
 from src.mcp_server import build_server
@@ -45,6 +47,8 @@ class StubCalendarSink(CalendarSink):
     def __init__(self, entries=None, todos=None):
         self.entries = entries or []
         self.todos = todos or []
+        self.created_events = []
+        self.created_todos = []
 
     def list_busy_blocks(self, window):
         return []
@@ -56,10 +60,12 @@ class StubCalendarSink(CalendarSink):
         return self.todos
 
     def create_event(self, event):
-        raise NotImplementedError
+        self.created_events.append(event)
+        return {"id": "event-1"}
 
     def create_todo(self, task):
-        raise NotImplementedError
+        self.created_todos.append(task)
+        return {"id": "todo-1"}
 
     def has_scheduled_event(self, source, source_id, start):
         raise NotImplementedError
@@ -155,6 +161,60 @@ async def test_list_todos_returns_structured_todos(settings):
     assert result.structuredContent["todos"] == [
         {"title": "Write report", "status": "needsAction", "notes": "due soon", "due": None}
     ]
+
+
+@pytest.mark.anyio
+async def test_create_tools_write_one_entry_and_one_todo(settings):
+    calendar_sink = StubCalendarSink()
+    server = build_server(settings, calendar_sink_factory=lambda _settings: calendar_sink)
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        tools = {tool.name: tool for tool in (await client.list_tools()).tools}
+        assert tools["create_calendar_entry"].annotations.readOnlyHint is False
+        assert tools["create_calendar_entry"].annotations.idempotentHint is False
+        assert tools["create_calendar_entry"].annotations.openWorldHint is True
+        await client.call_tool(
+            "create_calendar_entry",
+            {
+                "summary": "Focus",
+                "start": "2026-08-18T09:00:00",
+                "end": "2026-08-18T10:00:00",
+                "timezone": "Europe/Lisbon",
+                "description": "Deep work",
+                "attendees": ["person@example.com"],
+            },
+        )
+        result = await client.call_tool(
+            "create_todo", {"title": "Send notes", "note": "Before lunch", "due": "2026-08-18"}
+        )
+
+    assert len(calendar_sink.created_events) == 1
+    assert isinstance(calendar_sink.created_events[0], EventDTO)
+    assert calendar_sink.created_events[0].summary == "Focus"
+    assert len(calendar_sink.created_todos) == 1
+    assert isinstance(calendar_sink.created_todos[0], TaskDTO)
+    assert json.loads(result.content[0].text) == {"id": "todo-1"}
+
+
+@pytest.mark.anyio
+async def test_create_calendar_entry_rejects_invalid_input_before_upstream(settings):
+    calendar_sink = StubCalendarSink()
+    server = build_server(settings, calendar_sink_factory=lambda _settings: calendar_sink)
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        result = await client.call_tool(
+            "create_calendar_entry",
+            {
+                "summary": "Invalid",
+                "start": "2026-08-18T10:00:00",
+                "end": "2026-08-18T09:00:00",
+                "timezone": "Not/AZone",
+            },
+        )
+
+    assert result.isError is True
+    assert "Unknown timezone" in result.content[0].text
+    assert calendar_sink.created_events == []
 
 
 @pytest.mark.anyio

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -173,7 +173,7 @@ async def test_create_tools_write_one_entry_and_one_todo(settings):
         assert tools["create_calendar_entry"].annotations.readOnlyHint is False
         assert tools["create_calendar_entry"].annotations.idempotentHint is False
         assert tools["create_calendar_entry"].annotations.openWorldHint is True
-        await client.call_tool(
+        event_result = await client.call_tool(
             "create_calendar_entry",
             {
                 "summary": "Focus",
@@ -191,13 +191,36 @@ async def test_create_tools_write_one_entry_and_one_todo(settings):
     assert len(calendar_sink.created_events) == 1
     assert isinstance(calendar_sink.created_events[0], EventDTO)
     assert calendar_sink.created_events[0].summary == "Focus"
+    assert json.loads(event_result.content[0].text) == {"id": "event-1"}
     assert len(calendar_sink.created_todos) == 1
     assert isinstance(calendar_sink.created_todos[0], TaskDTO)
+    assert calendar_sink.created_todos[0].due == "2026-08-18T00:00:00Z"
     assert json.loads(result.content[0].text) == {"id": "todo-1"}
 
 
 @pytest.mark.anyio
-async def test_create_calendar_entry_rejects_invalid_input_before_upstream(settings):
+async def test_create_calendar_entry_rejects_unknown_timezone_before_upstream(settings):
+    calendar_sink = StubCalendarSink()
+    server = build_server(settings, calendar_sink_factory=lambda _settings: calendar_sink)
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        result = await client.call_tool(
+            "create_calendar_entry",
+            {
+                "summary": "Invalid",
+                "start": "2026-08-18T09:00:00",
+                "end": "2026-08-18T10:00:00",
+                "timezone": "Not/AZone",
+            },
+        )
+
+    assert result.isError is True
+    assert "Unknown timezone" in result.content[0].text
+    assert calendar_sink.created_events == []
+
+
+@pytest.mark.anyio
+async def test_create_calendar_entry_rejects_end_before_start(settings):
     calendar_sink = StubCalendarSink()
     server = build_server(settings, calendar_sink_factory=lambda _settings: calendar_sink)
 
@@ -208,12 +231,12 @@ async def test_create_calendar_entry_rejects_invalid_input_before_upstream(setti
                 "summary": "Invalid",
                 "start": "2026-08-18T10:00:00",
                 "end": "2026-08-18T09:00:00",
-                "timezone": "Not/AZone",
+                "timezone": "Europe/Lisbon",
             },
         )
 
     assert result.isError is True
-    assert "Unknown timezone" in result.content[0].text
+    assert "end must be after" in result.content[0].text
     assert calendar_sink.created_events == []
 
 


### PR DESCRIPTION
## What changed

Added MCP tools for creating one calendar entry or one to-do directly through the configured calendar sink. Calendar creation accepts summary, ISO start/end, timezone, description, and attendees; to-do creation accepts title, note, and due date. Both tools are annotated as external, non-read-only, non-repeatable writes.

## Why / Context

Assistants need to capture a single calendar block or to-do without running the full tracker sync. Validation happens before the sink is built or called, including IANA timezone, chronological times, required titles, and ISO due dates.

## How to test

Run `UV_CACHE_DIR=/tmp/auto-calendar-uv-cache uv run python -m pytest -q` and the required Ruff and mypy commands. The MCP tests assert one creation per call and clean rejection without an upstream call for invalid input.

## Checklist

- [x] Added direct calendar-entry creation
- [x] Added direct to-do creation
- [x] Added write annotations and validation tests
- [x] Full local verification pipeline passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to create Google Calendar entries.
  - Added the ability to create Google Tasks items.
  - Creation requests now return the newly generated item IDs.
  - Added validation for required fields, ISO 8601 dates, time zones, and valid calendar intervals.

- **Reliability**
  - Invalid calendar data is rejected before any external changes are made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->