### PR TITLE
Add account-free weekly planning tool

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -272,10 +272,16 @@ def _plan_week(
         )
         for item in items
     ]
-    busy = [
-        ScheduledBlock(title=commitment.title, start=commitment.start, end=commitment.end)
-        for commitment in commitments
-    ]
+    busy = []
+    for commitment in commitments:
+        start = _normalize_commitment_datetime(commitment.start, zone)
+        end = _normalize_commitment_datetime(commitment.end, zone)
+        if end <= start:
+            raise ConfigurationError(
+                f"Commitment {commitment.title!r} must end after it starts",
+                hint="Provide a commitment with an end datetime after its start datetime.",
+            )
+        busy.append(ScheduledBlock(title=commitment.title, start=start, end=end))
     result = schedule(work, busy, window)
     return WeekPlan(
         scheduled=[
@@ -289,6 +295,12 @@ def _plan_week(
             for item in result.unscheduled
         ],
     )
+
+
+def _normalize_commitment_datetime(value: datetime, zone: ZoneInfo) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=zone)
+    return value.astimezone(zone)
 
 
 def _parse_date(settings: Settings, label: str, value: str) -> datetime:

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from typing import Callable, List, Optional
 from zoneinfo import ZoneInfo
 
@@ -15,13 +15,15 @@ from mcp.types import ToolAnnotations
 
 from .auth import SCOPES
 from .dtos.event import EventDTO
-from .dtos.schedule import ScheduleWindow
+from .dtos.schedule import ScheduleWindow, ScheduledBlock
+from .dtos.work_item import Priority, Size, WorkItem
 from .dtos.task import TaskDTO
 from .errors import ConfigurationError
 from .integrations import build_calendar_sink, build_task_source
 from .providers.calendar_sink import CalendarSink
 from .providers.task_source import TaskSource
 from .settings import Settings
+from .scheduler import schedule
 
 SERVER_NAME = "auto-calendar"
 
@@ -71,6 +73,37 @@ class TrackerItem(BaseModel):
 
 class TrackerItems(BaseModel):
     items: List[TrackerItem]
+
+
+class PlanningItem(BaseModel):
+    title: str
+    priority: Optional[str] = None
+    size: Optional[str] = None
+    estimate: Optional[float] = None
+    id: Optional[str] = None
+
+
+class PlanningCommitment(BaseModel):
+    title: str
+    start: datetime
+    end: datetime
+
+
+class PlannedBlock(BaseModel):
+    title: str
+    start: datetime
+    end: datetime
+    source_id: Optional[str] = None
+
+
+class UnplannedItem(BaseModel):
+    title: str
+    reason: str
+
+
+class WeekPlan(BaseModel):
+    scheduled: List[PlannedBlock]
+    unscheduled: List[UnplannedItem]
 
 
 def build_server(
@@ -130,6 +163,35 @@ def build_server(
         return await asyncio.to_thread(_list_tracker_items, settings, task_source_factory, statuses)
 
     @server.tool(
+        name="plan_week",
+        description=(
+            "Plan work into free working-hour slots for a date range. Accepts work and existing "
+            "commitments directly and does not access configured accounts, network services, or "
+            "persist the plan. Returns both scheduled and unscheduled work."
+        ),
+        annotations=READ_ONLY,
+    )
+    async def plan_week(
+        items: List[PlanningItem],
+        start_date: str,
+        end_date: str,
+        working_day_start: str,
+        working_day_end: str,
+        timezone: Optional[str] = None,
+        commitments: Optional[List[PlanningCommitment]] = None,
+    ) -> WeekPlan:
+        return await asyncio.to_thread(
+            _plan_week,
+            items,
+            start_date,
+            end_date,
+            working_day_start,
+            working_day_end,
+            timezone,
+            commitments or [],
+        )
+
+    @server.tool(
         name="create_calendar_entry",
         description=(
             "Create exactly one calendar entry with a summary, start, end, and optional "
@@ -176,6 +238,57 @@ def build_server(
         )
 
     return server
+
+
+def _plan_week(
+    items: List[PlanningItem],
+    start_date: str,
+    end_date: str,
+    working_day_start: str,
+    working_day_end: str,
+    timezone: Optional[str],
+    commitments: List[PlanningCommitment],
+) -> WeekPlan:
+    zone = ZoneInfo(timezone or "UTC")
+    first = date.fromisoformat(start_date)
+    last = date.fromisoformat(end_date)
+    start_clock = time.fromisoformat(working_day_start)
+    end_clock = time.fromisoformat(working_day_end)
+    window = ScheduleWindow(
+        datetime.combine(first, start_clock, zone), datetime.combine(last, end_clock, zone)
+    )
+    if window.end <= window.start:
+        raise ConfigurationError(
+            "The planning date range and working hours must form a positive window",
+            hint="Use an end date on or after the start date and valid working hours.",
+        )
+    work = [
+        WorkItem(
+            id=item.id,
+            title=item.title,
+            priority=Priority[item.priority] if item.priority else None,
+            size=Size[item.size] if item.size else None,
+            estimate=item.estimate,
+        )
+        for item in items
+    ]
+    busy = [
+        ScheduledBlock(title=commitment.title, start=commitment.start, end=commitment.end)
+        for commitment in commitments
+    ]
+    result = schedule(work, busy, window)
+    return WeekPlan(
+        scheduled=[
+            PlannedBlock(
+                title=block.title, start=block.start, end=block.end, source_id=block.source_id
+            )
+            for block in result.scheduled
+        ],
+        unscheduled=[
+            UnplannedItem(title=item.work_item.title or "", reason=item.reason)
+            for item in result.unscheduled
+        ],
+    )
 
 
 def _parse_date(settings: Settings, label: str, value: str) -> datetime:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -146,6 +146,54 @@ async def test_list_calendar_entries_returns_structured_entries(settings):
 
 
 @pytest.mark.anyio
+async def test_plan_week_works_without_integrations_or_credentials(tmp_path):
+    settings = load_settings({"CAL_AUTO_CONFIG_DIR": str(tmp_path), "CAL_AUTO_TIMEZONE": "UTC"})
+    server = build_server(settings)
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        tools = {tool.name: tool for tool in (await client.list_tools()).tools}
+        assert tools["plan_week"].annotations.readOnlyHint is True
+        result = await client.call_tool(
+            "plan_week",
+            {
+                "items": [{"title": "Write report", "priority": "P1", "estimate": 2}],
+                "start_date": "2026-08-17",
+                "end_date": "2026-08-17",
+                "working_day_start": "09:00",
+                "working_day_end": "12:00",
+            },
+        )
+
+    assert result.structuredContent["scheduled"][0]["title"] == "Write report"
+    assert not (tmp_path / "credentials.json").exists()
+
+
+@pytest.mark.anyio
+async def test_plan_week_does_not_use_network_when_network_fails(settings, monkeypatch):
+    def fail_network(*args, **kwargs):
+        raise AssertionError("plan_week attempted a network call")
+
+    monkeypatch.setattr("requests.request", fail_network)
+    server = build_server(settings)
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        result = await client.call_tool(
+            "plan_week",
+            {
+                "items": [{"title": "Small task", "estimate": 1}],
+                "start_date": "2026-08-17",
+                "end_date": "2026-08-17",
+                "working_day_start": "09:00",
+                "working_day_end": "09:30",
+            },
+        )
+
+    assert result.structuredContent["unscheduled"] == [
+        {"title": "Small task", "reason": "No available time remains in the scheduling window"}
+    ]
+
+
+@pytest.mark.anyio
 async def test_list_todos_returns_structured_todos(settings):
     calendar_sink = StubCalendarSink(
         todos=[TodoItemDTO(title="Write report", status="needsAction", notes="due soon")]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -194,6 +194,33 @@ async def test_plan_week_does_not_use_network_when_network_fails(settings, monke
 
 
 @pytest.mark.anyio
+async def test_plan_week_normalizes_and_validates_commitments(settings):
+    server = build_server(settings)
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        result = await client.call_tool(
+            "plan_week",
+            {
+                "items": [{"title": "Focus work", "estimate": 1}],
+                "start_date": "2026-08-17",
+                "end_date": "2026-08-17",
+                "working_day_start": "09:00",
+                "working_day_end": "12:00",
+                "timezone": "Europe/Lisbon",
+                "commitments": [
+                    {
+                        "title": "Meeting",
+                        "start": "2026-08-17T09:00:00",
+                        "end": "2026-08-17T10:00:00",
+                    }
+                ],
+            },
+        )
+
+    assert result.structuredContent["scheduled"][0]["start"] == "2026-08-17T10:00:00+01:00"
+
+
+@pytest.mark.anyio
 async def test_list_todos_returns_structured_todos(settings):
     calendar_sink = StubCalendarSink(
         todos=[TodoItemDTO(title="Write report", status="needsAction", notes="due soon")]


### PR DESCRIPTION
## What changed

Added a read-only `plan_week` MCP tool that schedules caller-supplied work into working-hour slots and returns both scheduled blocks and unscheduled items with reasons. It accepts optional timezone and existing commitments without constructing any integration provider.

## Why / Context

The scheduler should be useful before a GitHub or Google account is connected. Keeping this tool on the pure scheduling path ensures credentials, configured providers, persistence, and network access are not required.

## How to test

Run the complete local pipeline:

```
uv sync --locked
uv run python -m ruff check .
uv run python -m ruff format --check .
uv run python -m pytest -q
uv run python -m mypy src tests
```

The MCP tests cover empty credentials and a forced network failure.

## Checklist

- [x] Tool is annotated read-only
- [x] Returns unscheduled work and reasons
- [x] Verified without credentials or outbound network calls
- [x] Complete local pipeline passes