### PR TITLE
Add one-request backlog sync with preview mode

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -24,6 +24,7 @@ from .providers.calendar_sink import CalendarSink
 from .providers.task_source import TaskSource
 from .settings import Settings
 from .scheduler import schedule
+from .sync import SyncResult, run_sync
 
 SERVER_NAME = "auto-calendar"
 
@@ -103,6 +104,22 @@ class UnplannedItem(BaseModel):
 
 class WeekPlan(BaseModel):
     scheduled: List[PlannedBlock]
+    unscheduled: List[UnplannedItem]
+
+
+class SyncBlock(BaseModel):
+    title: str
+    start: datetime
+    end: datetime
+    source_id: Optional[str] = None
+
+
+class SyncReport(BaseModel):
+    summary: str
+    preview: bool
+    planned: List[SyncBlock]
+    created: List[SyncBlock]
+    skipped: List[SyncBlock]
     unscheduled: List[UnplannedItem]
 
 
@@ -189,6 +206,30 @@ def build_server(
             working_day_end,
             timezone,
             commitments or [],
+        )
+
+    @server.tool(
+        name="sync_backlog",
+        description=(
+            "Fetch the schedulable backlog, fit it around existing calendar commitments, and "
+            "return the complete result. Preview by default; pass apply=true explicitly to "
+            "create calendar events and to-dos. Existing entries are skipped."
+        ),
+        annotations=WRITES_EXTERNAL_SYSTEM,
+    )
+    async def sync_backlog(
+        start_date: str,
+        end_date: str,
+        apply: bool = False,
+    ) -> SyncReport:
+        return await asyncio.to_thread(
+            _sync_backlog,
+            settings,
+            task_source_factory,
+            calendar_sink_factory,
+            start_date,
+            end_date,
+            apply,
         )
 
     @server.tool(
@@ -301,6 +342,70 @@ def _normalize_commitment_datetime(value: datetime, zone: ZoneInfo) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=zone)
     return value.astimezone(zone)
+
+
+def _sync_backlog(
+    settings: Settings,
+    task_source_factory: Callable[[Settings], TaskSource],
+    calendar_sink_factory: Callable[[Settings], CalendarSink],
+    start_date: str,
+    end_date: str,
+    apply: bool,
+) -> SyncReport:
+    try:
+        first = date.fromisoformat(start_date)
+        last = date.fromisoformat(end_date)
+        start_clock = time.fromisoformat(settings.working_day_start)
+        end_clock = time.fromisoformat(settings.working_day_end)
+    except ValueError as exc:
+        raise ConfigurationError(
+            "Invalid sync date", hint="Use YYYY-MM-DD for start_date and end_date."
+        ) from exc
+    zone = ZoneInfo(settings.timezone)
+    window_start = datetime.combine(first, start_clock, zone)
+    window_end = datetime.combine(last, end_clock, zone)
+    if window_end <= window_start:
+        raise ConfigurationError(
+            f"end date {end_date!r} is before start date {start_date!r}",
+            hint="Pass an end date on or after the start date.",
+        )
+    result = run_sync(
+        task_source_factory(settings),
+        calendar_sink_factory(settings),
+        ScheduleWindow(window_start, window_end),
+        settings,
+        apply=apply,
+    )
+    return _sync_report(result, apply)
+
+
+def _sync_report(result: SyncResult, apply: bool) -> SyncReport:
+    def block(value: ScheduledBlock) -> SyncBlock:
+        return SyncBlock(
+            title=value.title, start=value.start, end=value.end, source_id=value.source_id
+        )
+
+    planned = [block(value) for value in result.scheduled]
+    created = [block(value) for value in result.created]
+    skipped = [block(value) for value in result.skipped]
+    unscheduled = [
+        UnplannedItem(title=value.work_item.title or "", reason=value.reason)
+        for value in result.unscheduled
+    ]
+    mode = "Created" if apply else "Planned"
+    summary = (
+        f"{mode} {len(created) if apply else len(planned)} item(s); "
+        f"skipped {len(skipped)} already present; "
+        f"could not place {len(unscheduled)}."
+    )
+    return SyncReport(
+        summary=summary,
+        preview=not apply,
+        planned=planned,
+        created=created,
+        skipped=skipped,
+        unscheduled=unscheduled,
+    )
 
 
 def _parse_date(settings: Settings, label: str, value: str) -> datetime:

--- a/src/providers/google_calendar_sink.py
+++ b/src/providers/google_calendar_sink.py
@@ -67,11 +67,14 @@ def event_to_busy_block(
     if event_start >= window.end or event_end <= window.start:
         return None
 
+    private = event.get("extendedProperties", {}).get("private", {})
     return ScheduledBlock(
         title=cast(str, event.get("summary", "")),
         start=event_start,
         end=event_end,
         status="Backlog",
+        source=private.get("source_system"),
+        source_id=private.get("source_id"),
     )
 
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -35,10 +35,24 @@ def run_sync(
     work_items = task_source.list_work_items(settings.schedulable_statuses)
     busy_blocks = calendar_sink.list_busy_blocks(window)
 
+    scheduled_items = {
+        (block.source, block.source_id) for block in busy_blocks if block.source and block.source_id
+    }
+    scheduled_blocks: dict[tuple[str | None, str | None], ScheduledBlock] = {
+        (block.source, block.source_id): block
+        for block in busy_blocks
+        if block.source and block.source_id
+    }
+    skipped = [
+        scheduled_blocks[(item.source, item.id)]
+        for item in work_items
+        if (item.source, item.id) in scheduled_items
+    ]
+    work_items = [item for item in work_items if (item.source, item.id) not in scheduled_items]
+
     plan = schedule(work_items, busy_blocks, window)
 
     created: list[ScheduledBlock] = []
-    skipped: list[ScheduledBlock] = []
 
     if not apply:
         return SyncResult(plan=plan, created=created, skipped=skipped, unscheduled=plan.unscheduled)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -74,6 +74,21 @@ class StubCalendarSink(CalendarSink):
         raise NotImplementedError
 
 
+class SyncCalendarSink(StubCalendarSink):
+    def __init__(self, existing=None):
+        super().__init__()
+        self.existing = existing or set()
+
+    def list_busy_blocks(self, window):
+        return []
+
+    def has_scheduled_event(self, source, source_id, start):
+        return (source, source_id, start) in self.existing
+
+    def list_scheduled_todo_markers(self):
+        return set()
+
+
 class FailingTaskSource(TaskSource):
     def list_work_items(self, statuses=None):
         raise AuthorizationError(
@@ -166,6 +181,63 @@ async def test_plan_week_works_without_integrations_or_credentials(tmp_path):
 
     assert result.structuredContent["scheduled"][0]["title"] == "Write report"
     assert not (tmp_path / "credentials.json").exists()
+
+
+@pytest.mark.anyio
+async def test_sync_backlog_previews_without_writing(settings):
+    item = WorkItem(
+        id="1", source="github", title="Write report", priority=Priority.P1, status="Backlog"
+    )
+    source = StubTaskSource([item])
+    sink = SyncCalendarSink()
+    server = build_server(
+        settings,
+        task_source_factory=lambda _settings: source,
+        calendar_sink_factory=lambda _settings: sink,
+    )
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        tool = next(t for t in (await client.list_tools()).tools if t.name == "sync_backlog")
+        assert tool.annotations.readOnlyHint is False
+        result = await client.call_tool(
+            "sync_backlog", {"start_date": "2026-08-17", "end_date": "2026-08-17"}
+        )
+
+    assert result.structuredContent["preview"] is True
+    assert len(result.structuredContent["planned"]) == 1
+    assert result.structuredContent["created"] == []
+    assert sink.created_events == []
+    assert sink.created_todos == []
+
+
+@pytest.mark.anyio
+async def test_sync_backlog_applies_and_reports_existing_items(settings):
+    item = WorkItem(
+        id="1", source="github", title="Write report", priority=Priority.P1, status="Backlog"
+    )
+    source = StubTaskSource([item])
+    sink = SyncCalendarSink()
+    server = build_server(
+        settings,
+        task_source_factory=lambda _settings: source,
+        calendar_sink_factory=lambda _settings: sink,
+    )
+
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        first = await client.call_tool(
+            "sync_backlog",
+            {"start_date": "2026-08-17", "end_date": "2026-08-17", "apply": True},
+        )
+        planned = first.structuredContent["planned"][0]
+        sink.existing.add(("github", "1", datetime.fromisoformat(planned["start"])))
+        second = await client.call_tool(
+            "sync_backlog",
+            {"start_date": "2026-08-17", "end_date": "2026-08-17", "apply": True},
+        )
+
+    assert len(first.structuredContent["created"]) == 1
+    assert len(second.structuredContent["skipped"]) == 1
+    assert len(sink.created_events) == 1
 
 
 @pytest.mark.anyio

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,7 +2,7 @@ from dataclasses import replace
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from src.dtos.schedule import ScheduleWindow
+from src.dtos.schedule import ScheduleWindow, ScheduledBlock
 from src.dtos.work_item import Priority, Size, WorkItem
 from src.providers.calendar_sink import CalendarSink
 from src.providers.task_source import TaskSource
@@ -119,6 +119,27 @@ def test_apply_creates_new_items_and_skips_existing():
     assert len(result.skipped) == 1
     assert len(calendar_sink.created_events) == 1
     assert len(calendar_sink.created_todos) == 2
+
+
+def test_apply_skips_existing_event_returned_as_busy_block():
+    item = _work_item("1", "Write docs")
+    existing = StubCalendarSink(
+        busy_blocks=[
+            ScheduledBlock(
+                title=item.title,
+                start=datetime(2026, 8, 17, 9, tzinfo=TZ),
+                end=datetime(2026, 8, 17, 11, tzinfo=TZ),
+                source="github",
+                source_id="1",
+            )
+        ]
+    )
+
+    result = run_sync(StubTaskSource([item]), existing, _window(), _settings(), apply=True)
+
+    assert result.created == []
+    assert len(result.skipped) == 1
+    assert existing.created_events == []
 
 
 def test_unscheduled_items_are_reported():


### PR DESCRIPTION
## What changed

Adds the `sync_backlog` MCP capability, which fetches the schedulable backlog, schedules it around existing calendar commitments, and returns planned, created, skipped, and unplaced items with a human-readable summary.

Preview is the default. Passing `apply=true` explicitly creates calendar events and to-dos, while existing entries are skipped.

## Why / Context

The common workflow should be available as one assistant request without requiring step-by-step composition. Because it writes to external accounts, the tool is annotated as a write-capable operation but performs no writes unless the caller explicitly opts in.

## How to test

- `uv sync --locked`
- `uv run python -m ruff check .`
- `uv run python -m ruff format --check .`
- `uv run python -m pytest -q`
- `uv run python -m mypy src tests`

All checks pass: 104 tests and no mypy issues.

## Checklist

- [x] Preview mode performs no writes
- [x] Apply mode reports created and already-present items
- [x] Repeated apply skips existing entries
- [x] Unscheduled work and counts are included in the response