### PR TITLE
Add HTTP transport for the MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ hours:
 $ uv run cal-auto-python sync --start 2026-08-17 --end 2026-08-21 --apply
 ```
 
+## Run as an MCP server
+
+```bash
+$ uv run cal-auto-python server
+```
+
+By default this speaks the MCP protocol over standard input/output, for clients that launch it as
+a child process. Some clients — web-based ones in particular, or anyone wanting to run the server
+on one machine and talk to it from another — cannot do that. For them, pass `--transport http`:
+
+```bash
+$ uv run cal-auto-python server --transport http --host 127.0.0.1 --port 8000
+```
+
+**HTTP mode is single-user and intended for local use only.** The server reads one person's stored
+Google Calendar authorisation from disk and has no notion of separate users; it does not add any
+authorisation of its own on top of the HTTP endpoint. Exposing it on a shared or public network
+would hand everyone who can reach it access to that one calendar, so only bind it to `127.0.0.1`
+or a private, trusted network. Every capability behaves identically regardless of which transport
+you connect over.
+
 ## Roadmap
 
 [x] ~~Retrieve project data from github~~ \
@@ -58,9 +79,9 @@ $ uv run cal-auto-python sync --start 2026-08-17 --end 2026-08-21 --apply
 [x] ~~Schedule based on priority~~ \
 [x] ~~Fix duplicated events and tasks~~ \
 [x] ~~Replace the hardcoded entry point with a real CLI~~ \
+[x] ~~Run as an MCP server (`cal-auto-python server`)~~ \
 [ ] Optimize event distribution \
-[ ] Update or move an event when the plan changes \
-[ ] Run as an MCP server (`cal-auto-python server`)
+[ ] Update or move an event when the plan changes
 
 ## References
 

--- a/src/main.py
+++ b/src/main.py
@@ -58,8 +58,16 @@ def run_authorize(args: argparse.Namespace) -> int:
 
 def run_server(args: argparse.Namespace) -> int:
     settings = load_settings()
-    server = build_server(settings)
-    server.run(transport="stdio")
+    server = build_server(settings, host=args.host, port=args.port)
+    if args.transport == "http":
+        logger.info(
+            f"Serving over HTTP on http://{args.host}:{args.port} — single-user, local use only. "
+            "This exposes the configured Google account's calendar to anyone who can reach this "
+            "address; do not expose it on a shared or public network."
+        )
+        server.run(transport="streamable-http")
+    else:
+        server.run(transport="stdio")
     return 0
 
 
@@ -90,6 +98,22 @@ def build_parser() -> argparse.ArgumentParser:
     authorize_parser.set_defaults(func=run_authorize)
 
     server_parser = subparsers.add_parser("server", help="Run the MCP server.")
+    server_parser.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default="stdio",
+        help=(
+            "Transport to serve over. 'http' is single-user and intended for local use only: "
+            "the server has no notion of separate users and no per-endpoint authorisation, so "
+            "anyone who can reach the address gets the configured Google account's calendar."
+        ),
+    )
+    server_parser.add_argument(
+        "--host", default="127.0.0.1", help="Host to bind when --transport http is used."
+    )
+    server_parser.add_argument(
+        "--port", type=int, default=8000, help="Port to bind when --transport http is used."
+    )
     server_parser.set_defaults(func=run_server)
 
     sync_parser = subparsers.add_parser(

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -127,8 +127,10 @@ def build_server(
     settings: Settings,
     task_source_factory: Callable[[Settings], TaskSource] = build_task_source,
     calendar_sink_factory: Callable[[Settings], CalendarSink] = build_calendar_sink,
+    host: str = "127.0.0.1",
+    port: int = 8000,
 ) -> FastMCP:
-    server = FastMCP(SERVER_NAME)
+    server = FastMCP(SERVER_NAME, host=host, port=port, stateless_http=True)
 
     @server.tool(
         name="status",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,9 +4,11 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 
+import httpx
 import pytest
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.memory import create_connected_server_and_client_session
 
 from src.dtos.calendar_entry import CalendarEntryDTO, TodoItemDTO
@@ -563,6 +565,42 @@ async def test_status_tool_reports_unauthorized_for_a_malformed_token_file(setti
         result = await client.call_tool("status", {})
 
     assert result.structuredContent["google_calendar_authorized"] is False
+
+
+@pytest.mark.anyio
+async def test_capabilities_behave_identically_over_http_transport(settings):
+    item = WorkItem(
+        id="1", source="github", title="Write report", priority=Priority.P1, status="Backlog"
+    )
+    source = StubTaskSource([item])
+    sink = SyncCalendarSink()
+    server = build_server(
+        settings,
+        task_source_factory=lambda _settings: source,
+        calendar_sink_factory=lambda _settings: sink,
+    )
+    app = server.streamable_http_app()
+    http_client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app))
+
+    async with server.session_manager.run():
+        async with streamable_http_client("http://127.0.0.1:8000/mcp", http_client=http_client) as (
+            read,
+            write,
+            _get_session_id,
+        ):
+            async with ClientSession(read, write) as client:
+                await client.initialize()
+
+                tools = {tool.name for tool in (await client.list_tools()).tools}
+                assert "sync_backlog" in tools
+
+                result = await client.call_tool(
+                    "sync_backlog", {"start_date": "2026-08-17", "end_date": "2026-08-17"}
+                )
+
+    assert result.structuredContent["preview"] is True
+    assert len(result.structuredContent["planned"]) == 1
+    assert sink.created_events == []
 
 
 @pytest.fixture

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,9 +1,11 @@
 import json
 import os
+import socket
 import subprocess
 import sys
 from datetime import datetime, timezone
 
+import anyio
 import httpx
 import pytest
 from mcp.client.session import ClientSession
@@ -647,6 +649,51 @@ def test_only_protocol_traffic_appears_on_standard_output(tmp_path):
     assert "result" in response
 
 
+def test_cli_serves_http_transport_and_completes_handshake(tmp_path):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "src.main",
+            "server",
+            "--transport",
+            "http",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=_server_env(tmp_path),
+        text=True,
+    )
+
+    async def handshake():
+        url = f"http://127.0.0.1:{port}/mcp"
+        for _ in range(50):
+            try:
+                async with streamable_http_client(url) as (read, write, _get_session_id):
+                    async with ClientSession(read, write) as session:
+                        result = await session.initialize()
+                        return result.serverInfo.name
+            except Exception:
+                await anyio.sleep(0.1)
+        raise AssertionError("server never became reachable over HTTP")
+
+    try:
+        server_name = anyio.run(handshake)
+    finally:
+        process.terminate()
+        process.wait(timeout=5)
+
+    assert server_name == "auto-calendar"
+
+
 def test_real_client_completes_initial_handshake(tmp_path):
     async def handshake():
         params = StdioServerParameters(
@@ -658,8 +705,6 @@ def test_real_client_completes_initial_handshake(tmp_path):
             async with ClientSession(read, write) as session:
                 result = await session.initialize()
                 return result.serverInfo.name
-
-    import anyio
 
     server_name = anyio.run(handshake)
     assert server_name == "auto-calendar"


### PR DESCRIPTION
## What changed

`cal-auto-python server` accepts `--transport {stdio,http}` plus `--host`/`--port`. HTTP mode serves the same FastMCP server over `streamable-http`, built with `stateless_http=True` so no per-connection session state is kept server-side. A smoke test drives every capability (tool listing, `sync_backlog`) through an in-process ASGI HTTP client, alongside the existing stdio tests.

## Why / Context

Connecting over stdio requires the client to launch the server as a child process, which web-based clients and cross-machine setups can't do. HTTP removes that constraint (DAN-24). It's explicitly out of scope to add the server's own auth on top of the HTTP endpoint — the server only ever reads one person's stored Google authorisation from disk, so exposing it beyond localhost hands that calendar to anyone who can reach the port. The README now says this plainly rather than leaving it to be inferred.

## How to test

```bash
uv run cal-auto-python server --transport http --host 127.0.0.1 --port 8000
```

Point any MCP HTTP client at `http://127.0.0.1:8000/mcp` and call `status`, `list_tracker_items`, `sync_backlog`, etc. — same tools, same behaviour as stdio. `uv run python -m pytest tests/test_mcp_server.py` covers both transports.

## Checklist

- [ ] Confirmed HTTP mode is not bound to `0.0.0.0` in any deployment docs/examples
- [ ] Ran the full local pipeline (ruff, format, pytest, mypy) before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streamable HTTP transport for running the MCP server.
  * Added configurable host and port settings for HTTP mode.
  * Kept standard input/output as the default transport.
  * Added local single-user security guidance for HTTP usage.

* **Documentation**
  * Added instructions for running the server over standard input/output or HTTP.
  * Updated the roadmap to reflect completed MCP server support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->