### PR TITLE
Add MCP registry manifest and package ownership marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,18 @@ jobs:
       - run: python -m ruff format --check .
       - run: python -m mypy src tests
 
+  registry-manifest:
+    name: Registry manifest version check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python scripts/check_manifest_version.py
+
   package:
     name: Package build and install check
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Automatic Calendar in Python
 
+mcp-name: io.github.danielsousaoliveira/cal-auto-python
+
 Automatically schedule tasks from github into google calendar, using Python
 
 ## Setup

--- a/scripts/check_manifest_version.py
+++ b/scripts/check_manifest_version.py
@@ -1,0 +1,33 @@
+"""Fail if server.json's declared version drifts from pyproject.toml's package version."""
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def main() -> int:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    package_version = pyproject["project"]["version"]
+
+    manifest = json.loads((ROOT / "server.json").read_text())
+    manifest_version = manifest["version"]
+    package_versions = {package["version"] for package in manifest["packages"]}
+
+    mismatches = {manifest_version, *package_versions} - {package_version}
+    if mismatches:
+        print(
+            f"server.json version(s) {sorted(mismatches)} do not match "
+            f"pyproject.toml version {package_version!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"server.json matches pyproject.toml version {package_version!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server.json
+++ b/server.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-06-18/server.schema.json",
+  "name": "io.github.danielsousaoliveira/cal-auto-python",
+  "description": "Schedule a GitHub Projects backlog into Google Calendar, as a CLI or an MCP server.",
+  "repository": {
+    "url": "https://github.com/danielsousaoliveira/auto-calendar-python",
+    "source": "github"
+  },
+  "version": "0.0.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "cal-auto-python",
+      "version": "0.0.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "GITHUB_TOKEN",
+          "description": "GitHub personal access token used to query the GitHub Project.",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "GITHUB_PROJECT_ID",
+          "description": "GitHub Projects V2 node ID of the board to read.",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "CAL_AUTO_TIMEZONE",
+          "description": "IANA timezone name used to schedule events, e.g. Europe/Lisbon.",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "CAL_AUTO_CONFIG_DIR",
+          "description": "Directory holding Google OAuth credentials and token. Defaults to the platform config directory.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "CAL_AUTO_WORKING_DAY_START",
+          "description": "Start of the working day as HH:MM. Defaults to 09:00.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "CAL_AUTO_WORKING_DAY_END",
+          "description": "End of the working day as HH:MM. Defaults to 17:00.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "CAL_AUTO_CALENDAR_ID",
+          "description": "Google Calendar ID to schedule events into. Defaults to primary.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "CAL_AUTO_TASK_LIST_ID",
+          "description": "Google Tasks list ID to create tasks in. Defaults to @default.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "CAL_AUTO_ATTENDEES",
+          "description": "Comma-separated email addresses to invite to scheduled events.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "CAL_AUTO_SCHEDULABLE_STATUSES",
+          "description": "Comma-separated GitHub Project status names to schedule. Defaults to Backlog.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "CAL_AUTO_COUNT_ALL_DAY_EVENTS",
+          "description": "Whether all-day events count against free/busy slots. Defaults to false.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

Adds `server.json`, an MCP registry manifest declaring `io.github.danielsousaoliveira/cal-auto-python` under the account's GitHub namespace, with the repository, version, and PyPI package details (identifier, stdio transport, and the environment variables a user needs to set). Adds the matching `mcp-name: io.github.danielsousaoliveira/cal-auto-python` ownership marker to the top of `README.md`, and a CI job that fails if `server.json`'s version drifts from `pyproject.toml`'s.

## Why / Context

The registry only accepts a listing after verifying the publisher controls the package it points at. For PyPI that proof is the `mcp-name` marker string appearing in the package's published description — which for this project is the readme, since `pyproject.toml` already sets `readme = "README.md"`, so the marker reaches the registry with no extra wiring needed. The manifest name and the marker string must be identical, so they're kept in the same PR. A version mismatch between the manifest and the package is an easy drift to introduce later and only visible after a failed publish (which burns a version number, since PyPI never allows reuse), so a CI check catches it before that happens. Publishing itself is out of scope — this PR only establishes the identity DAN-27's automated publish will use.

## How to test

`uv run python scripts/check_manifest_version.py` passes with the current versions and fails if you bump one file's version without the other. `uv run python -m pytest -q`, ruff, and mypy all pass unchanged.

## Checklist

- [x] `server.json` name and `README.md` marker match exactly
- [x] `pyproject.toml` version and `server.json` version(s) match