### PR TITLE
Move scheduled calendar events instead of duplicating them

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -119,6 +119,7 @@ class SyncReport(BaseModel):
     preview: bool
     planned: List[SyncBlock]
     created: List[SyncBlock]
+    updated: List[SyncBlock]
     skipped: List[SyncBlock]
     unscheduled: List[UnplannedItem]
 
@@ -392,6 +393,7 @@ def _sync_report(result: SyncResult, apply: bool) -> SyncReport:
 
     planned = [block(value) for value in result.scheduled]
     created = [block(value) for value in result.created]
+    updated = [block(value) for value in result.updated]
     skipped = [block(value) for value in result.skipped]
     unscheduled = [
         UnplannedItem(title=value.work_item.title or "", reason=value.reason)
@@ -400,6 +402,7 @@ def _sync_report(result: SyncResult, apply: bool) -> SyncReport:
     mode = "Created" if apply else "Planned"
     summary = (
         f"{mode} {len(created) if apply else len(planned)} item(s); "
+        f"moved {len(updated)}; "
         f"skipped {len(skipped)} already present; "
         f"could not place {len(unscheduled)}."
     )
@@ -408,6 +411,7 @@ def _sync_report(result: SyncResult, apply: bool) -> SyncReport:
         preview=not apply,
         planned=planned,
         created=created,
+        updated=updated,
         skipped=skipped,
         unscheduled=unscheduled,
     )

--- a/src/providers/calendar_sink.py
+++ b/src/providers/calendar_sink.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
 from typing import List, Set
 
 from ..dtos.calendar_entry import CalendarEntryDTO, TodoItemDTO
@@ -28,10 +27,6 @@ class CalendarSink(ABC):
     @abstractmethod
     def create_todo(self, task: TaskDTO) -> dict:
         """Create a to-do item and return the created resource."""
-
-    @abstractmethod
-    def has_scheduled_event(self, source: str, source_id: str, start: datetime) -> bool:
-        """Return whether an event for this exact scheduled block already exists."""
 
     @abstractmethod
     def find_scheduled_events(self, source: str, source_id: str) -> List[dict]:

--- a/src/providers/calendar_sink.py
+++ b/src/providers/calendar_sink.py
@@ -34,5 +34,13 @@ class CalendarSink(ABC):
         """Return whether an event for this exact scheduled block already exists."""
 
     @abstractmethod
+    def find_scheduled_events(self, source: str, source_id: str) -> List[dict]:
+        """Return every managed event for this work item, sorted by start time."""
+
+    @abstractmethod
+    def update_event(self, event_id: str, event: EventDTO) -> dict:
+        """Update an existing calendar event and return the updated resource."""
+
+    @abstractmethod
     def list_scheduled_todo_markers(self) -> Set[str]:
         """Return the markers of every to-do already created, fetched once per call."""

--- a/src/providers/google_calendar_sink.py
+++ b/src/providers/google_calendar_sink.py
@@ -30,6 +30,20 @@ def block_identity(
     return f"{source}:{source_id}:{start.isoformat()}"
 
 
+def event_matches_block(event: dict, block: ScheduledBlock) -> bool:
+    start = event.get("start", {}).get("dateTime")
+    end = event.get("end", {}).get("dateTime")
+    if not start or not end:
+        return False
+    event_start = datetime.fromisoformat(start)
+    event_end = datetime.fromisoformat(end)
+    if event_start.tzinfo is None:
+        event_start = event_start.replace(tzinfo=block.start.tzinfo)
+    if event_end.tzinfo is None:
+        event_end = event_end.replace(tzinfo=block.end.tzinfo)
+    return event_start == block.start and event_end == block.end
+
+
 def event_color_id(source_id: str) -> str:
     digest = hashlib.sha256(source_id.encode("utf-8")).digest()
     return str((digest[0] % EVENT_COLOR_COUNT) + 1)
@@ -285,6 +299,29 @@ class GoogleCalendarSink(CalendarSink):
             .execute()
         )
         return bool(result.get("items"))
+
+    def find_scheduled_events(self, source: str, source_id: str) -> List[dict]:
+        result = (
+            self.calendar_service.events()
+            .list(
+                calendarId=self.settings.calendar_id,
+                privateExtendedProperty=[
+                    f"source_system={source}",
+                    f"source_id={source_id}",
+                ],
+                maxResults=50,
+            )
+            .execute()
+        )
+        items = result.get("items", [])
+        return sorted(items, key=lambda event: event.get("start", {}).get("dateTime", ""))
+
+    def update_event(self, event_id: str, event: EventDTO) -> dict:
+        return (
+            self.calendar_service.events()
+            .update(calendarId=self.settings.calendar_id, eventId=event_id, body=event.to_dict())
+            .execute()
+        )
 
     def list_scheduled_todo_markers(self) -> Set[str]:
         markers: Set[str] = set()

--- a/src/providers/google_calendar_sink.py
+++ b/src/providers/google_calendar_sink.py
@@ -301,19 +301,26 @@ class GoogleCalendarSink(CalendarSink):
         return bool(result.get("items"))
 
     def find_scheduled_events(self, source: str, source_id: str) -> List[dict]:
-        result = (
-            self.calendar_service.events()
-            .list(
-                calendarId=self.settings.calendar_id,
-                privateExtendedProperty=[
-                    f"source_system={source}",
-                    f"source_id={source_id}",
-                ],
-                maxResults=50,
+        items: List[dict] = []
+        page_token = None
+        while True:
+            result = (
+                self.calendar_service.events()
+                .list(
+                    calendarId=self.settings.calendar_id,
+                    privateExtendedProperty=[
+                        f"source_system={source}",
+                        f"source_id={source_id}",
+                    ],
+                    maxResults=50,
+                    pageToken=page_token,
+                )
+                .execute()
             )
-            .execute()
-        )
-        items = result.get("items", [])
+            items.extend(result.get("items", []))
+            page_token = result.get("nextPageToken")
+            if not page_token:
+                break
         return sorted(items, key=lambda event: event.get("start", {}).get("dateTime", ""))
 
     def update_event(self, event_id: str, event: EventDTO) -> dict:

--- a/src/providers/google_calendar_sink.py
+++ b/src/providers/google_calendar_sink.py
@@ -287,19 +287,6 @@ class GoogleCalendarSink(CalendarSink):
             .execute()
         )
 
-    def has_scheduled_event(self, source: str, source_id: str, start: datetime) -> bool:
-        identity = block_identity(source, source_id, start)
-        result = (
-            self.calendar_service.events()
-            .list(
-                calendarId=self.settings.calendar_id,
-                privateExtendedProperty=[f"auto_calendar_id={identity}"],
-                maxResults=1,
-            )
-            .execute()
-        )
-        return bool(result.get("items"))
-
     def find_scheduled_events(self, source: str, source_id: str) -> List[dict]:
         items: List[dict] = []
         page_token = None

--- a/src/sync.py
+++ b/src/sync.py
@@ -6,7 +6,12 @@ from dataclasses import dataclass, field
 
 from .dtos.schedule import ScheduleWindow, ScheduledBlock, SchedulePlan, UnscheduledItem
 from .providers.calendar_sink import CalendarSink
-from .providers.google_calendar_sink import build_event, build_todos, todo_marker
+from .providers.google_calendar_sink import (
+    build_event,
+    build_todos,
+    event_matches_block,
+    todo_marker,
+)
 from .providers.task_source import TaskSource
 from .scheduler import schedule
 from .settings import Settings
@@ -16,6 +21,7 @@ from .settings import Settings
 class SyncResult:
     plan: SchedulePlan
     created: list[ScheduledBlock] = field(default_factory=list)
+    updated: list[ScheduledBlock] = field(default_factory=list)
     skipped: list[ScheduledBlock] = field(default_factory=list)
     unscheduled: list[UnscheduledItem] = field(default_factory=list)
     applied: bool = False
@@ -35,42 +41,48 @@ def run_sync(
     work_items = task_source.list_work_items(settings.schedulable_statuses)
     busy_blocks = calendar_sink.list_busy_blocks(window)
 
-    scheduled_items = {
-        (block.source, block.source_id) for block in busy_blocks if block.source and block.source_id
-    }
-    scheduled_blocks: dict[tuple[str | None, str | None], ScheduledBlock] = {
-        (block.source, block.source_id): block
+    work_item_keys = {(item.source, item.id) for item in work_items}
+    external_busy_blocks = [
+        block
         for block in busy_blocks
-        if block.source and block.source_id
-    }
-    skipped = [
-        scheduled_blocks[(item.source, item.id)]
-        for item in work_items
-        if (item.source, item.id) in scheduled_items
+        if not (
+            block.source and block.source_id and (block.source, block.source_id) in work_item_keys
+        )
     ]
-    work_items = [item for item in work_items if (item.source, item.id) not in scheduled_items]
 
-    plan = schedule(work_items, busy_blocks, window)
+    plan = schedule(work_items, external_busy_blocks, window)
 
     created: list[ScheduledBlock] = []
+    updated: list[ScheduledBlock] = []
+    skipped: list[ScheduledBlock] = []
 
     if not apply:
         return SyncResult(plan=plan, created=created, skipped=skipped, unscheduled=plan.unscheduled)
 
     existing_todo_markers = calendar_sink.list_scheduled_todo_markers()
+    existing_events_by_item: dict[tuple[str, str], list[dict]] = {}
+    consumed_by_item: dict[tuple[str, str], int] = {}
 
     for task in plan.scheduled:
-        already_scheduled = (
-            task.source
-            and task.source_id
-            and calendar_sink.has_scheduled_event(task.source, task.source_id, task.start)
-        )
-        if already_scheduled:
+        existing_event = None
+        if task.source and task.source_id:
+            key = (task.source, task.source_id)
+            if key not in existing_events_by_item:
+                existing_events_by_item[key] = calendar_sink.find_scheduled_events(*key)
+            matches = existing_events_by_item[key]
+            index = consumed_by_item.get(key, 0)
+            if index < len(matches):
+                consumed_by_item[key] = index + 1
+                existing_event = matches[index]
+
+        if existing_event is None:
+            calendar_sink.create_event(build_event(task, settings))
+            created.append(task)
+        elif event_matches_block(existing_event, task):
             skipped.append(task)
         else:
-            event = build_event(task, settings)
-            calendar_sink.create_event(event)
-            created.append(task)
+            calendar_sink.update_event(existing_event["id"], build_event(task, settings))
+            updated.append(task)
 
         for index, todo in enumerate(build_todos(task)):
             marker = todo_marker(task.source, task.source_id, index)
@@ -81,5 +93,10 @@ def run_sync(
                 existing_todo_markers.add(marker)
 
     return SyncResult(
-        plan=plan, created=created, skipped=skipped, unscheduled=plan.unscheduled, applied=True
+        plan=plan,
+        created=created,
+        updated=updated,
+        skipped=skipped,
+        unscheduled=plan.unscheduled,
+        applied=True,
     )

--- a/tests/test_google_calendar_sink.py
+++ b/tests/test_google_calendar_sink.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
@@ -337,53 +338,6 @@ def test_create_todo_inserts_into_the_configured_task_list(tmp_path, mocker):
     assert kwargs["tasklist"] == "tasks"
 
 
-def test_has_scheduled_event_queries_by_a_single_block_identity_property(tmp_path, mocker):
-    service = mocker.Mock()
-    service.events.return_value.list.return_value.execute.return_value = {
-        "items": [{"summary": "A"}]
-    }
-    sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
-    start = datetime(2024, 1, 1, 9, tzinfo=timezone.utc)
-
-    assert sink.has_scheduled_event("github", "item-1", start) is True
-    _, kwargs = service.events.return_value.list.call_args
-    assert kwargs["privateExtendedProperty"] == [
-        f"auto_calendar_id={block_identity('github', 'item-1', start)}"
-    ]
-
-
-def test_has_scheduled_event_is_false_when_no_event_matches(tmp_path, mocker):
-    service = mocker.Mock()
-    service.events.return_value.list.return_value.execute.return_value = {"items": []}
-    sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
-
-    assert (
-        sink.has_scheduled_event("github", "item-1", datetime(2024, 1, 1, 9, tzinfo=timezone.utc))
-        is False
-    )
-
-
-def test_has_scheduled_event_does_not_match_a_different_chunk_of_the_same_item(tmp_path, mocker):
-    service = mocker.Mock()
-    sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
-    day_one = datetime(2024, 1, 1, 9, tzinfo=timezone.utc)
-    day_two = datetime(2024, 1, 2, 9, tzinfo=timezone.utc)
-
-    def list_events(**kwargs):
-        wanted = kwargs["privateExtendedProperty"][0]
-        matches = (
-            [{"summary": "A"}]
-            if wanted == f"auto_calendar_id={block_identity('github', 'item-1', day_one)}"
-            else []
-        )
-        return mocker.Mock(execute=lambda: {"items": matches})
-
-    service.events.return_value.list.side_effect = list_events
-
-    assert sink.has_scheduled_event("github", "item-1", day_one) is True
-    assert sink.has_scheduled_event("github", "item-1", day_two) is False
-
-
 def test_find_scheduled_events_queries_by_source_and_source_id(tmp_path, mocker):
     service = mocker.Mock()
     service.events.return_value.list.return_value.execute.return_value = {
@@ -485,19 +439,23 @@ def test_list_scheduled_todo_markers_scans_notes_across_pages(tmp_path, mocker):
 def test_applying_the_same_plan_twice_creates_each_event_and_todo_once(tmp_path, mocker):
     calendar_service = mocker.Mock()
     tasks_service = mocker.Mock()
-    created_events: list = []
+    events_by_id: dict = {}
     created_todos: list = []
+    next_id = [0]
 
     def list_events(**kwargs):
-        wanted = kwargs["privateExtendedProperty"][0]
-        matches = [event for event in created_events if event == wanted]
+        matches = [event for event in events_by_id.values()]
         return mocker.Mock(execute=lambda: {"items": matches})
 
     def insert_event(calendarId, body):
-        created_events.append(
-            f"auto_calendar_id={body['extendedProperties']['private']['auto_calendar_id']}"
-        )
-        return mocker.Mock(execute=lambda: body)
+        next_id[0] += 1
+        event_id = f"evt-{next_id[0]}"
+        events_by_id[event_id] = {"id": event_id, "start": body["start"], "end": body["end"]}
+        return mocker.Mock(execute=lambda: {"id": event_id, **body})
+
+    def update_event(calendarId, eventId, body):
+        events_by_id[eventId] = {"id": eventId, "start": body["start"], "end": body["end"]}
+        return mocker.Mock(execute=lambda: {"id": eventId, **body})
 
     def list_tasks(**kwargs):
         return mocker.Mock(execute=lambda: {"items": [{"notes": t.notes} for t in created_todos]})
@@ -508,6 +466,7 @@ def test_applying_the_same_plan_twice_creates_each_event_and_todo_once(tmp_path,
 
     calendar_service.events.return_value.list.side_effect = list_events
     calendar_service.events.return_value.insert.side_effect = insert_event
+    calendar_service.events.return_value.update.side_effect = update_event
     tasks_service.tasks.return_value.list.side_effect = list_tasks
     tasks_service.tasks.return_value.insert.side_effect = insert_todo
 
@@ -521,21 +480,36 @@ def test_applying_the_same_plan_twice_creates_each_event_and_todo_once(tmp_path,
         source_id="item-1",
     )
 
-    def apply_plan():
+    def apply_plan(plan_block):
         existing_markers = sink.list_scheduled_todo_markers()
-        if not sink.has_scheduled_event(block.source, block.source_id, block.start):
-            sink.create_event(build_event(block, settings(tmp_path)))
-        for index, todo in enumerate(build_todos(block)):
-            marker = todo_marker(block.source, block.source_id, index)
+        matches = sink.find_scheduled_events(plan_block.source, plan_block.source_id)
+        event = build_event(plan_block, settings(tmp_path))
+        if not matches:
+            sink.create_event(event)
+        elif not event_matches_block(matches[0], plan_block):
+            sink.update_event(matches[0]["id"], event)
+        for index, todo in enumerate(build_todos(plan_block)):
+            marker = todo_marker(plan_block.source, plan_block.source_id, index)
             if marker in existing_markers:
                 continue
             sink.create_todo(todo)
 
-    apply_plan()
-    apply_plan()
+    apply_plan(block)
+    apply_plan(block)
 
-    assert len(created_events) == 1
+    assert len(events_by_id) == 1
     assert len(created_todos) == 2
+
+    moved_block = replace(
+        block,
+        start=datetime(2024, 1, 2, 9, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 2, 11, tzinfo=timezone.utc),
+    )
+    apply_plan(moved_block)
+
+    assert len(events_by_id) == 1
+    remaining_event = next(iter(events_by_id.values()))
+    assert remaining_event["start"]["dateTime"] == "2024-01-02T09:00:00"
 
 
 def entries_window():

--- a/tests/test_google_calendar_sink.py
+++ b/tests/test_google_calendar_sink.py
@@ -404,6 +404,23 @@ def test_find_scheduled_events_queries_by_source_and_source_id(tmp_path, mocker)
     assert [event["id"] for event in events] == ["evt-1", "evt-2"]
 
 
+def test_find_scheduled_events_paginates_through_all_results(tmp_path, mocker):
+    service = mocker.Mock()
+    service.events.return_value.list.return_value.execute.side_effect = [
+        {
+            "items": [{"id": "evt-2", "start": {"dateTime": "2024-01-02T09:00:00+00:00"}}],
+            "nextPageToken": "page-2",
+        },
+        {"items": [{"id": "evt-1", "start": {"dateTime": "2024-01-01T09:00:00+00:00"}}]},
+    ]
+    sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
+
+    events = sink.find_scheduled_events("github", "item-1")
+
+    assert [event["id"] for event in events] == ["evt-1", "evt-2"]
+    assert service.events.return_value.list.call_count == 2
+
+
 def test_update_event_calls_the_calendar_api_with_the_event_id(tmp_path, mocker):
     service = mocker.Mock()
     service.events.return_value.update.return_value.execute.return_value = {"id": "evt-1"}

--- a/tests/test_google_calendar_sink.py
+++ b/tests/test_google_calendar_sink.py
@@ -12,6 +12,7 @@ from src.providers.google_calendar_sink import (
     build_event,
     build_todos,
     event_color_id,
+    event_matches_block,
     event_to_busy_block,
     event_to_calendar_entry,
     task_to_todo_item,
@@ -381,6 +382,65 @@ def test_has_scheduled_event_does_not_match_a_different_chunk_of_the_same_item(t
 
     assert sink.has_scheduled_event("github", "item-1", day_one) is True
     assert sink.has_scheduled_event("github", "item-1", day_two) is False
+
+
+def test_find_scheduled_events_queries_by_source_and_source_id(tmp_path, mocker):
+    service = mocker.Mock()
+    service.events.return_value.list.return_value.execute.return_value = {
+        "items": [
+            {"id": "evt-2", "start": {"dateTime": "2024-01-02T09:00:00+00:00"}},
+            {"id": "evt-1", "start": {"dateTime": "2024-01-01T09:00:00+00:00"}},
+        ]
+    }
+    sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
+
+    events = sink.find_scheduled_events("github", "item-1")
+
+    _, kwargs = service.events.return_value.list.call_args
+    assert kwargs["privateExtendedProperty"] == [
+        "source_system=github",
+        "source_id=item-1",
+    ]
+    assert [event["id"] for event in events] == ["evt-1", "evt-2"]
+
+
+def test_update_event_calls_the_calendar_api_with_the_event_id(tmp_path, mocker):
+    service = mocker.Mock()
+    service.events.return_value.update.return_value.execute.return_value = {"id": "evt-1"}
+    sink = GoogleCalendarSink(service, mocker.Mock(), settings(tmp_path))
+    block = ScheduledBlock(
+        title="A",
+        start=datetime(2024, 1, 2, 9, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 2, 11, tzinfo=timezone.utc),
+        source="github",
+        source_id="item-1",
+    )
+
+    result = sink.update_event("evt-1", build_event(block, settings(tmp_path)))
+
+    assert result == {"id": "evt-1"}
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["eventId"] == "evt-1"
+    assert kwargs["body"]["start"]["dateTime"] == "2024-01-02T09:00:00"
+
+
+def test_event_matches_block_compares_start_and_end():
+    block = ScheduledBlock(
+        title="A",
+        start=datetime(2024, 1, 1, 9, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 1, 11, tzinfo=timezone.utc),
+    )
+    matching_event = {
+        "start": {"dateTime": "2024-01-01T09:00:00+00:00"},
+        "end": {"dateTime": "2024-01-01T11:00:00+00:00"},
+    }
+    moved_event = {
+        "start": {"dateTime": "2024-01-01T13:00:00+00:00"},
+        "end": {"dateTime": "2024-01-01T15:00:00+00:00"},
+    }
+
+    assert event_matches_block(matching_event, block) is True
+    assert event_matches_block(moved_event, block) is False
 
 
 def test_list_scheduled_todo_markers_scans_notes_across_pages(tmp_path, mocker):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -71,9 +71,6 @@ class StubCalendarSink(CalendarSink):
         self.created_todos.append(task)
         return {"id": "todo-1"}
 
-    def has_scheduled_event(self, source, source_id, start):
-        raise NotImplementedError
-
     def find_scheduled_events(self, source, source_id):
         raise NotImplementedError
 
@@ -93,9 +90,6 @@ class SyncCalendarSink(StubCalendarSink):
 
     def list_busy_blocks(self, window):
         return []
-
-    def has_scheduled_event(self, source, source_id, start):
-        return (source, source_id, start) in self.existing
 
     def create_event(self, event):
         self._event_ids += 1
@@ -149,9 +143,6 @@ class FailingCalendarSink(CalendarSink):
         raise NotImplementedError
 
     def create_todo(self, task):
-        raise NotImplementedError
-
-    def has_scheduled_event(self, source, source_id, start):
         raise NotImplementedError
 
     def find_scheduled_events(self, source, source_id):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -74,6 +74,12 @@ class StubCalendarSink(CalendarSink):
     def has_scheduled_event(self, source, source_id, start):
         raise NotImplementedError
 
+    def find_scheduled_events(self, source, source_id):
+        raise NotImplementedError
+
+    def update_event(self, event_id, event):
+        raise NotImplementedError
+
     def list_scheduled_todo_markers(self):
         raise NotImplementedError
 
@@ -81,13 +87,35 @@ class StubCalendarSink(CalendarSink):
 class SyncCalendarSink(StubCalendarSink):
     def __init__(self, existing=None):
         super().__init__()
-        self.existing = existing or set()
+        self.existing = existing or {}
+        self.updated_events = []
+        self._event_ids = 0
 
     def list_busy_blocks(self, window):
         return []
 
     def has_scheduled_event(self, source, source_id, start):
         return (source, source_id, start) in self.existing
+
+    def create_event(self, event):
+        self._event_ids += 1
+        event_id = f"event-{self._event_ids}"
+        properties = (event.extendedProperties or {}).get("private", {})
+        source = properties.get("source_system")
+        source_id = properties.get("source_id")
+        if source and source_id:
+            self.existing.setdefault((source, source_id), []).append(
+                {"id": event_id, "start": event.start, "end": event.end}
+            )
+        self.created_events.append(event)
+        return {"id": event_id}
+
+    def find_scheduled_events(self, source, source_id):
+        return self.existing.get((source, source_id), [])
+
+    def update_event(self, event_id, event):
+        self.updated_events.append((event_id, event))
+        return {"id": event_id}
 
     def list_scheduled_todo_markers(self):
         return set()
@@ -124,6 +152,12 @@ class FailingCalendarSink(CalendarSink):
         raise NotImplementedError
 
     def has_scheduled_event(self, source, source_id, start):
+        raise NotImplementedError
+
+    def find_scheduled_events(self, source, source_id):
+        raise NotImplementedError
+
+    def update_event(self, event_id, event):
         raise NotImplementedError
 
     def list_scheduled_todo_markers(self):
@@ -239,8 +273,6 @@ async def test_sync_backlog_applies_and_reports_existing_items(settings):
             "sync_backlog",
             {"start_date": "2026-08-17", "end_date": "2026-08-17", "apply": True},
         )
-        planned = first.structuredContent["planned"][0]
-        sink.existing.add(("github", "1", datetime.fromisoformat(planned["start"])))
         second = await client.call_tool(
             "sync_backlog",
             {"start_date": "2026-08-17", "end_date": "2026-08-17", "apply": True},

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -24,11 +24,8 @@ class StubTaskSource(TaskSource):
 
 
 class StubCalendarSink(CalendarSink):
-    def __init__(
-        self, busy_blocks=None, scheduled_identities=None, todo_markers=None, scheduled_events=None
-    ):
+    def __init__(self, busy_blocks=None, todo_markers=None, scheduled_events=None):
         self.busy_blocks = busy_blocks or []
-        self.scheduled_identities = scheduled_identities or set()
         self.todo_markers = set(todo_markers or set())
         self.scheduled_events = scheduled_events or {}
         self.created_events = []
@@ -51,9 +48,6 @@ class StubCalendarSink(CalendarSink):
     def create_todo(self, task):
         self.created_todos.append(task)
         return {}
-
-    def has_scheduled_event(self, source, source_id, start):
-        return (source, source_id, start) in self.scheduled_identities
 
     def find_scheduled_events(self, source, source_id):
         return self.scheduled_events.get((source, source_id), [])

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -24,12 +24,16 @@ class StubTaskSource(TaskSource):
 
 
 class StubCalendarSink(CalendarSink):
-    def __init__(self, busy_blocks=None, scheduled_identities=None, todo_markers=None):
+    def __init__(
+        self, busy_blocks=None, scheduled_identities=None, todo_markers=None, scheduled_events=None
+    ):
         self.busy_blocks = busy_blocks or []
         self.scheduled_identities = scheduled_identities or set()
         self.todo_markers = set(todo_markers or set())
+        self.scheduled_events = scheduled_events or {}
         self.created_events = []
         self.created_todos = []
+        self.updated_events = []
 
     def list_busy_blocks(self, window):
         return self.busy_blocks
@@ -50,6 +54,13 @@ class StubCalendarSink(CalendarSink):
 
     def has_scheduled_event(self, source, source_id, start):
         return (source, source_id, start) in self.scheduled_identities
+
+    def find_scheduled_events(self, source, source_id):
+        return self.scheduled_events.get((source, source_id), [])
+
+    def update_event(self, event_id, event):
+        self.updated_events.append((event_id, event))
+        return {"id": event_id}
 
     def list_scheduled_todo_markers(self):
         return self.todo_markers
@@ -84,6 +95,14 @@ def _work_item(item_id, title):
     )
 
 
+def _existing_event(event_id, start, end):
+    return {
+        "id": event_id,
+        "start": {"dateTime": start.isoformat()},
+        "end": {"dateTime": end.isoformat()},
+    }
+
+
 def test_dry_run_plans_without_writing():
     task_source = StubTaskSource([_work_item("1", "Write docs")])
     calendar_sink = StubCalendarSink()
@@ -104,42 +123,79 @@ def test_apply_creates_new_items_and_skips_existing():
 
     dry_run = run_sync(task_source, calendar_sink, _window(), _settings(), apply=False)
     already_scheduled_block = dry_run.plan.scheduled[0]
-    calendar_sink.scheduled_identities = {
-        (
-            already_scheduled_block.source,
-            already_scheduled_block.source_id,
-            already_scheduled_block.start,
-        )
+    calendar_sink.scheduled_events = {
+        (already_scheduled_block.source, already_scheduled_block.source_id): [
+            _existing_event(
+                "existing-1", already_scheduled_block.start, already_scheduled_block.end
+            )
+        ]
     }
 
     result = run_sync(task_source, calendar_sink, _window(), _settings(), apply=True)
 
     assert result.applied
     assert len(result.created) == 1
+    assert len(result.updated) == 0
     assert len(result.skipped) == 1
     assert len(calendar_sink.created_events) == 1
     assert len(calendar_sink.created_todos) == 2
 
 
-def test_apply_skips_existing_event_returned_as_busy_block():
+def test_apply_skips_existing_event_that_still_matches_the_plan():
     item = _work_item("1", "Write docs")
+    start = datetime(2026, 8, 17, 9, tzinfo=TZ)
+    end = datetime(2026, 8, 17, 11, tzinfo=TZ)
     existing = StubCalendarSink(
         busy_blocks=[
-            ScheduledBlock(
-                title=item.title,
-                start=datetime(2026, 8, 17, 9, tzinfo=TZ),
-                end=datetime(2026, 8, 17, 11, tzinfo=TZ),
-                source="github",
-                source_id="1",
-            )
-        ]
+            ScheduledBlock(title=item.title, start=start, end=end, source="github", source_id="1")
+        ],
+        scheduled_events={("github", "1"): [_existing_event("existing-1", start, end)]},
     )
 
     result = run_sync(StubTaskSource([item]), existing, _window(), _settings(), apply=True)
 
     assert result.created == []
+    assert result.updated == []
     assert len(result.skipped) == 1
     assert existing.created_events == []
+    assert existing.updated_events == []
+
+
+def test_apply_moves_existing_event_when_the_plan_reschedules_it():
+    urgent_item = _work_item("1", "Fix outage")
+    already_scheduled_item = replace(_work_item("2", "Write docs"), priority=Priority.P2)
+    start = datetime(2026, 8, 17, 9, tzinfo=TZ)
+    end = datetime(2026, 8, 17, 11, tzinfo=TZ)
+    existing = StubCalendarSink(
+        busy_blocks=[
+            ScheduledBlock(
+                title=already_scheduled_item.title,
+                start=start,
+                end=end,
+                source="github",
+                source_id="2",
+            )
+        ],
+        scheduled_events={("github", "2"): [_existing_event("existing-2", start, end)]},
+    )
+
+    result = run_sync(
+        StubTaskSource([urgent_item, already_scheduled_item]),
+        existing,
+        _window(),
+        _settings(),
+        apply=True,
+    )
+
+    assert len(result.created) == 1
+    assert len(result.updated) == 1
+    assert result.updated[0].source_id == "2"
+    assert len(existing.created_events) == 1
+    assert existing.created_events[0].extendedProperties["private"]["source_id"] == "1"
+    assert len(existing.updated_events) == 1
+    updated_event_id, updated_event = existing.updated_events[0]
+    assert updated_event_id == "existing-2"
+    assert updated_event.start["dateTime"] != start.strftime("%Y-%m-%dT%H:%M:%S")
 
 
 def test_unscheduled_items_are_reported():


### PR DESCRIPTION
## What changed

`run_sync` no longer excludes work items with an existing calendar event from scheduling. Instead, every backlog item is scheduled fresh each run (its own prior events are excluded from the busy pool so it's free to move), and the result is reconciled against any managed event already found for that work item: unchanged plans are left alone, moved plans update the existing event in place, and only genuinely new items get a fresh insert.

`CalendarSink` gains `find_scheduled_events(source, source_id)` (lookup by source/source_id, ignoring start time) and `update_event(event_id, event)`. `GoogleCalendarSink` implements both, plus a small `event_matches_block` helper used to decide update vs. skip.

## Why / Context

The previous sync treated any item with an existing calendar event as already handled and dropped it from scheduling entirely. That meant a changed priority, estimate, or calendar commitment never moved the event — the old slot just sat there, disconnected from the current plan.

## How to test

`uv run python -m pytest -q tests/test_sync.py tests/test_google_calendar_sink.py -v` covers the new behavior directly, in particular `test_apply_moves_existing_event_when_the_plan_reschedules_it` (event updated, not duplicated) and `test_apply_skips_existing_event_that_still_matches_the_plan` (preview/no-op path). Full suite: `uv run python -m pytest -q`.

## Checklist

- [x] A preview (`apply=False`) still makes no calendar writes
- [x] A rerun with an unchanged plan updates nothing
- [x] A rerun with a changed plan updates the existing event instead of inserting a second one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar synchronization now detects existing events and skips unchanged items.
  * Rescheduled items update existing calendar events instead of creating duplicates.
  * Sync reports now include updated items and moved-item counts.
  * Duplicate events for the same work item are handled sequentially.

* **Bug Fixes**
  * Prevented duplicate calendar events during repeated synchronization.
  * Improved matching of scheduled blocks across time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->